### PR TITLE
v2.3 draft: exempt SREJ from §6.4.11 checkpoint retransmission (prose companion to the figc4.5 fix, #38)

### DIFF
--- a/doc/ax.25.2.3.1_May_26.md
+++ b/doc/ax.25.2.3.1_May_26.md
@@ -1176,7 +1176,7 @@ When the SREJ mechanism is used, the receiving station retains correctly receive
 
 ###### 4.4.5.1 T1 Timer Recovery
 
-If a transmission error causes a TNC to fail to receive (or to receive and discard) a single I frame, or the last I frame in a sequence of I frames, then the TNC does not detect a send-sequence-number error and consequently does not transmit an REJ/SREJ. The TNC that transmitted the unacknowledged I frame(s) following the completion of timeout period T1, takes appropriate recovery action to determine when I frame retransmission as described in Section 6.4.10 should begin.
+If a transmission error causes a TNC to fail to receive (or to receive and discard) a single I frame, or the last I frame in a sequence of I frames, then the TNC does not detect a send-sequence-number error and consequently does not transmit an REJ/SREJ. The TNC that transmitted the unacknowledged I frame(s) following the completion of timeout period T1, takes appropriate recovery action to determine when I frame retransmission as described in Section 6.4.11 should begin.
 This condition is cleared by the reception of an acknowledgement for the sent frame(s), or by the link being reset.
 
 ###### 4.4.5.2 Timer T3 Recovery
@@ -1511,6 +1511,8 @@ Whenever a TNC enters a busy condition, it indicates this by sending an RNR resp
 If the originating TNC’s timer T1 expires while awaiting the distant TNC’s acknowledgement of an I frame transmitted, the originating TNC restarts timer T1 and transmits an appropriate supervisory command frame (RR or RNR) with the P bit set.
 
 If the TNC correctly receives a supervisory response frame with the F bit set and with an N(R) within the range from the last N(R) received to the last N(S) sent plus one, the TNC restarts timer T1 and sets its send state variable V(S) to the received N(R). It may then resume with I frame transmission or retransmission, as appropriate. If, on the other hand, the TNC correctly receives a supervisory response frame with the F bit not set, or an I frame or supervisory command frame, and with an N(R) within the range from the last N(R) received to the last N(S) sent plus one, the TNC does not restart timer T1; it uses the received N(R) as an indication of acknowledgement of transmitted I frames up to and including I frame numbered N(R)-1.
+
+The checkpoint retransmission described in the previous paragraph applies to the RR, RNR and REJ supervisory frames; it does not apply to SREJ. An SREJ response frame received while awaiting acknowledgement is processed as described in Sections 4.3.2.4 and 6.4.8: the TNC does not set its send state variable V(S) to the received N(R), and retransmits only the individual I frame indicated by the N(R) of the SREJ frame; I frames transmitted following that I frame are not retransmitted as the result of receiving the SREJ frame. Acknowledgement is inferred from an SREJ frame only when its F bit is set to “1”, in which case I frames numbered up to N(R)-1 inclusive are considered acknowledged; an SREJ frame with the F bit set to “0” does not indicate acknowledgement of I frames.
 
 If timer T1 expires before a supervisory response frame with the F bit set is received, the TNC retransmits an appropriate supervisory command frame (RR or RNR) with the P bit set. After N2 attempts to get a supervisory response frame with the F bit set from the distant TNC, the originating TNC initiates a link resetting procedure as described in Section 6.5.
 


### PR DESCRIPTION
**For WG review (NJ7P confirmation wanted before merge)** — this is the prose companion to the figc4.5 SREJ figure correction (packet-net/ax25sdl#69). Refs #38; does not close it (the Annex C figures still carry the defect until the corrected GraphML renders land).

## Why the prose needs this

§6.4.11 (Waiting Acknowledgement), second paragraph, as written applies to **any** supervisory response:

- F=1 → restart T1 **and set V(S) := N(R)** — a checkpoint rewind that implies go-back-N retransmission;
- F=0 (or I/command frames) → N(R) "used as an indication of acknowledgement" up to N(R)−1.

Both statements are contradicted, for SREJ, by §4.3.2.4 ("retransmission of the **single** I frame numbered N(R)"; "I frames transmitted following the I frame indicated by the SREJ frame are **not** retransmitted"; F=0 → "does not indicate acknowledgement") and §6.4.8. This over-broad paragraph is the plausible **root cause of the figc4.5 defect**: the figure-as-drawn (SREJ → Invoke Retransmission, i.e. go-back-N) is a literal reading of §6.4.11 applied to the SREJ column — consistent with direwolf's attribution of that box to a 2006 REJ-column cut-and-paste (`src/ax25_link.c:4181-4186`).

The change adds one paragraph to §6.4.11 scoping checkpoint retransmission to RR/RNR/REJ and deferring SREJ to §4.3.2.4/§6.4.8 (V(S) unaltered, single-frame retransmit, F=1-only acknowledgement). No T1 semantics are legislated beyond what §6.4.11 already says, deliberately — T2/T1 interaction is #16's territory.

## Evidence backing the adjudication

- Prose: §4.3.2.4, §4.4.4, §6.4.8 (all already unambiguous on single-frame retransmission).
- Implementations: direwolf `resend_for_srej` retransmits only N(R) and never touches V(S) (`ax25_link.c:4216-4234`); acknowledges on F=1 only (`:4128-4138`).
- Executable: the corrected state tables (packet-net/ax25sdl#69) were verified two independent ways — a downstream oracle-equivalence run against packet.net's conformance/property suites (14 defect failures under figure-as-drawn, all green under the correction), and clean-room golden traces authored from the prose cited above *before* execution, which fail on the current tables and pass on the corrected ones (packet-net/ax25sdl#76).

## Also in this PR

§4.4.5.1's cross-reference pointed T1-recovery retransmission at "Section 6.4.10" (Sending a Busy Indication); the described procedure is §6.4.11. Stale reference inherited from the 2.2.4 text (line 1217 there) — fixed in the v2.3 draft only, per the convention that 2.2.4 stays as published.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NYgDR92cdiqzn1APXyoQgv