### PR TITLE
Audit of figure-to-markdown transcriptions: fix Figure D.3 response arrows

### DIFF
--- a/doc/ax.25.2.2.4_Oct_25.md
+++ b/doc/ax.25.2.2.4_Oct_25.md
@@ -2806,7 +2806,8 @@ The other primitives work in groups of four with the Request from the station A 
         |   .Request     |-------------------->| DL-CONNECT     |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    UA Response      |                |
+        |                |                     |  UA Response   |
+        |                |    UA Response      |<---------------|
         | DL-CONNECT     |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |
@@ -2816,7 +2817,8 @@ The other primitives work in groups of four with the Request from the station A 
         |   .Request     |-------------------->| MDL-NEGOTIATE  |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    XID Response     |                |
+        |                |                     |  XID Response  |
+        |                |    XID Response     |<---------------|
         | MDL-NEGOTIATE  |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |
@@ -2826,7 +2828,8 @@ The other primitives work in groups of four with the Request from the station A 
         |   .Request     |-------------------->| DL-DATA        |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    RR               |                |
+        |                |                     |      RR        |
+        |                |    RR Frame         |<---------------|
         | DL-DATA        |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |
@@ -2836,7 +2839,8 @@ The other primitives work in groups of four with the Request from the station A 
         |   .Request     |-------------------->| DL-DISCONNECT  |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    DM Response      |                |
+        |                |                     |  DM Response   |
+        |                |    DM Response      |<---------------|
         | DL-DISCONNECT  |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |

--- a/doc/ax.25.2.3-draft.md
+++ b/doc/ax.25.2.3-draft.md
@@ -2537,7 +2537,8 @@ The other primitives work in groups of four with the request from the station A 
         |   .Request     |-------------------->| DL-CONNECT     |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    UA Response      |                |
+        |                |                     |  UA Response   |
+        |                |    UA Response      |<---------------|
         | DL-CONNECT     |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |
@@ -2547,7 +2548,8 @@ The other primitives work in groups of four with the request from the station A 
         |   .Request     |-------------------->| MDL-NEGOTIATE  |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    XID Response     |                |
+        |                |                     |  XID Response  |
+        |                |    XID Response     |<---------------|
         | MDL-NEGOTIATE  |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |
@@ -2557,7 +2559,8 @@ The other primitives work in groups of four with the request from the station A 
         |   .Request     |-------------------->| DL-DATA        |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    RR               |                |
+        |                |                     |      RR        |
+        |                |    RR Frame         |<---------------|
         | DL-DATA        |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |
@@ -2567,7 +2570,8 @@ The other primitives work in groups of four with the request from the station A 
         |   .Request     |-------------------->| DL-DISCONNECT  |
         |                |                     |   .Indication  |
         |                |                     |                |
-        |                |    DM Response      |                |
+        |                |                     |  DM Response   |
+        |                |    DM Response      |<---------------|
         | DL-DISCONNECT  |<--------------------|                |
         |   .Confirm     |                     |                |
         |                |                     |                |


### PR DESCRIPTION
## Scope

Semantic audit of every piece of content that was originally a figure/PNG and now lives as native markdown (tables, ASCII diagrams, fenced blocks) in **both** documents. Earlier text-level diffing (#73) verified token presence but treated table reflow as noise, so this pass checked **row/column association and diagram structure** against the source PDF — each figure compared with its rendered PDF page.

## What was checked

| Figure(s) | Method | Result |
| --- | --- | --- |
| 2.1 (OSI layers), 2.2/2.3 (FSM models), 2.4 (primitive sequence) | Rendered-page visual compare (these are raster images in the PDF — pdftotext extracts nothing, so they'd never been text-verified) | ✅ match, incl. bracket spans and the source's "Station A … Station A" quirk in 2.4 |
| 3.1a/3.1b (frame construction), 3.3 (address field) | Visual + layout text | ✅ match |
| 3.4, 3.5, 3.7, 3.8 (octet tables) | **Programmatic**: binary↔hex↔ASCII consistency (`hex == ord(char)<<1`) on every row, both docs | ✅ all consistent (the only flags are the five deliberately-sic Figure 3.6 rows in v2.2.4, per #73) |
| 4.1a/b, 4.2a/b, 4.3a/b, 4.4 (control fields) | Visual compare + cross-check against standard AX.25 encodings (RR/RNR/REJ/SREJ, SABM(E)/DISC/DM/UA/FRMR/UI/XID/TEST) | ✅ match |
| 6.1 (C/R encoding), 6.2 (segment header) | Visual compare | ✅ match — 6.2's suspected "7-bit" row was a pdftotext artifact: the PDF splits bit 7 into its own sub-column ("0 \| 0001000"), the markdown's `00001000` is semantically identical |
| D.1 (queue model), D.2 (object relationships) | Visual compare | ✅ match |
| **D.3 (connection-oriented exchange)** | Visual compare | ❌ **defect found — fixed here** |

## The fix

The source Figure D.3 draws, in each of its four panels, an **inward response arrow on the remote station's side** — UA Response, XID Response, RR, DM Response flowing from the right-hand station into its DLSAP — and labels the third panel's returning frame "**RR Frame**". The markdown transcription omitted all four response arrows and labelled the return frame just "RR", losing the Request → Indication → Response → Confirm four-primitive structure the Appendix D prose describes ("The other primitives work in groups of four…").

Restored identically in both documents. Two deliberate asymmetries preserved:
- the v2.3 draft keeps its "Station B" right-hand header (Bill's correction, present in the draft as received; the source figure says "Station A" on both sides, which v2.2.4 faithfully retains);
- v2.2.4's caption-above-figure placement (cosmetic, consistent with the doc's other figures) is untouched.

No changelog-table row added: the fix is identical in both docs, so it isn't a v2.2→v2.3 difference.

CRLF endings in the draft verified intact; ASCII block column alignment verified (all lines equal width).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XodLuT1R8a4HY76RSZrqFi