### PR TITLE
tools: structural + visual diff for the SVG figure renders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /.claude
 __pycache__/
+/build/

--- a/README.md
+++ b/README.md
@@ -31,6 +31,26 @@ The derived-artifact chain: **graphml → yaml happens here** — CI's `transcri
 
 The transcription discipline (shape classes, encode-then-verify, revision provenance) is documented in ax25sdl's [docs/](https://github.com/packet-net/ax25sdl/tree/main/docs) (`sdl-primer.md`, `sdl-transcription-runbook.md`).
 
+### Reviewing a figure change — `tools/svgdiff/`
+
+The svg/ renders are auto-laid-out, so adding one node reflows the whole page and a plain image diff of the render is unreadable: a single added decision diamond moves nearly every edge by a few pixels. [tools/svgdiff/svg_diff.py](tools/svgdiff/svg_diff.py) diffs the figure's **structure** instead — nodes, edge endpoints and free labels get position-independent signatures, so layout movement cancels out and only genuinely added or removed content is reported.
+
+```sh
+# every SVG that differs on a PR branch, against the point it forked from
+python3 tools/svgdiff/svg_diff.py main my-branch --all --merge-base
+```
+
+```
+spec-sdl/v2.2-errata/data-link/svg/DataLink_Connected.svg
+  + node   V(r) < N(s) < V(r) + k?
+  + edge   N(s) == V(r)? → V(r) < N(s) < V(r) + k?
+  + edge   V(r) < N(s) < V(r) + k? → Discard Contents of I Frame
+  − edge   N(s) == V(r)? → Reject Exception?
+  viewer: build/svgdiff/svgdiff-DataLink_Connected.html
+```
+
+Alongside the change list it writes a self-contained HTML viewer per figure (both renders embedded; no network, no dependencies) with new/old/swipe/onion-skin/blink/difference views and a clickable change list that zooms straight to each change. `--format markdown` emits the same list as a table for a PR comment; `--no-html` skips the viewers. Output lands in the gitignored `build/svgdiff/`.
+
 Please feel free to raise issues and PRs vs this repo.
 
 ## Future targets

--- a/tools/svgdiff/svg_diff.py
+++ b/tools/svgdiff/svg_diff.py
@@ -1,0 +1,198 @@
+#!/usr/bin/env python3
+"""Structural + visual diff for the committed SVG figure renders.
+
+The svg/ renders are auto-laid-out, so adding a single node reflows the whole
+page: a plain pixel diff of one added decision diamond reports ~55 changed
+regions and is useless for review. This tool diffs the *structure* instead --
+nodes, edge endpoints and free labels are given position-independent
+signatures, so pure layout movement cancels out and only genuinely added or
+removed content is reported.
+
+For each changed figure it prints the change list and writes a self-contained
+HTML viewer (both renders embedded, no network, no dependencies) offering
+new/old/swipe/onion/blink/difference views with a clickable change list that
+zooms straight to each change.
+
+Usage (from the repo root):
+  # every SVG that differs between two revisions
+  python3 tools/svgdiff/svg_diff.py main HEAD --all
+
+  # a PR branch, against the point it forked from
+  python3 tools/svgdiff/svg_diff.py main pr81 --all --merge-base
+
+  # specific figures only
+  python3 tools/svgdiff/svg_diff.py main HEAD spec-sdl/v2.2-errata/data-link/svg/DataLink_Connected.svg
+
+  # change list only, for a CI comment
+  python3 tools/svgdiff/svg_diff.py main HEAD --all --format markdown --no-html
+"""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import html
+import json
+import subprocess
+import sys
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+import svg_struct  # noqa: E402
+
+REPO = Path(__file__).resolve().parents[2]
+TEMPLATE = Path(__file__).resolve().parent / "viewer_template.html"
+
+
+def git(*args: str, binary: bool = False):
+    r = subprocess.run(["git", "-C", str(REPO), *args], capture_output=True)
+    if r.returncode != 0:
+        sys.exit(f"git {' '.join(args)} failed: {r.stderr.decode(errors='replace').strip()}")
+    return r.stdout if binary else r.stdout.decode("utf-8", "replace")
+
+
+def blob(rev: str, path: str) -> bytes | None:
+    """File content at a revision, or None if it does not exist there."""
+    r = subprocess.run(["git", "-C", str(REPO), "show", f"{rev}:{path}"], capture_output=True)
+    return r.stdout if r.returncode == 0 else None
+
+
+def changed_svgs(oldrev: str, newrev: str) -> list[str]:
+    out = git("diff", "--name-only", oldrev, newrev, "--", "*.svg")
+    return [line for line in out.splitlines() if line.strip()]
+
+
+def build_viewer(name: str, oldrev: str, newrev: str,
+                 old_bytes: bytes, new_bytes: bytes, regions: list, stats: dict) -> str:
+    struct = [
+        {
+            "kind": r["kind"], "what": r["what"], "side": r["side"], "text": r["text"],
+            "x": r["box"][0] - 8, "y": r["box"][1] - 8,
+            "w": r["box"][2] + 16, "h": r["box"][3] + 16,
+        }
+        for r in regions
+    ]
+
+    def data_uri(b: bytes) -> str:
+        return "data:image/svg+xml;base64," + base64.b64encode(b).decode()
+
+    return (TEMPLATE.read_text(encoding="utf-8")
+            .replace("__STRUCT__", json.dumps(struct))
+            .replace("__STATS__", json.dumps(stats))
+            .replace("__OLD__", data_uri(old_bytes))
+            .replace("__NEW__", data_uri(new_bytes))
+            .replace("__NAME__", html.escape(name))
+            .replace("__OLDREV__", html.escape(oldrev))
+            .replace("__NEWREV__", html.escape(newrev)))
+
+
+SIGN = {"added": "+", "removed": "−"}
+
+
+def report_text(results: list[dict], oldrev: str, newrev: str) -> str:
+    lines = []
+    for res in results:
+        lines.append(f"\n{res['path']}")
+        if res["note"]:
+            lines.append(f"  {res['note']}")
+        for r in res["regions"]:
+            lines.append(f"  {SIGN[r['kind']]} {r['what']:6} {r['text']}")
+        if not res["regions"] and not res["note"]:
+            lines.append("  layout changed, but no nodes, edges or labels added or removed")
+        if res["html"]:
+            lines.append(f"  viewer: {res['html']}")
+    if not results:
+        lines.append(f"no SVG differs between {oldrev} and {newrev}")
+    return "\n".join(lines).lstrip("\n")
+
+
+def report_markdown(results: list[dict], oldrev: str, newrev: str) -> str:
+    if not results:
+        return f"No SVG figure differs between `{oldrev}` and `{newrev}`."
+    out = [f"### SVG figure changes (`{oldrev}` → `{newrev}`)", ""]
+    for res in results:
+        out.append(f"**`{res['path']}`**")
+        if res["note"]:
+            out.append("")
+            out.append(f"_{res['note'].capitalize()}._")
+            out.append("")
+            continue
+        st = res["stats"]
+        out.append("")
+        out.append(f"nodes {st['old']['nodes']}→{st['new']['nodes']}, "
+                   f"edges {st['old']['edges']}→{st['new']['edges']}, "
+                   f"labels {st['old']['labels']}→{st['new']['labels']}")
+        out.append("")
+        if not res["regions"]:
+            out.append("_Layout reflowed; no nodes, edges or labels added or removed._")
+            out.append("")
+            continue
+        out.append("| | what | change |")
+        out.append("| --- | --- | --- |")
+        for r in res["regions"]:
+            text = r["text"].replace("|", "\\|")
+            out.append(f"| {SIGN[r['kind']]} | {r['what']} | `{text}` |")
+        out.append("")
+    return "\n".join(out)
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(
+        description="Structural + visual diff for the committed SVG figure renders.")
+    ap.add_argument("oldrev")
+    ap.add_argument("newrev")
+    ap.add_argument("paths", nargs="*", help="SVG paths; omit (or pass --all) for every changed SVG")
+    ap.add_argument("--all", action="store_true",
+                    help="diff every SVG that differs between the two revisions")
+    ap.add_argument("--merge-base", action="store_true",
+                    help="compare against the merge base of the two revisions, not oldrev's tip")
+    ap.add_argument("--out", default="build/svgdiff",
+                    help="directory for the generated viewers (default: build/svgdiff)")
+    ap.add_argument("--format", choices=("text", "markdown"), default="text")
+    ap.add_argument("--no-html", action="store_true", help="print the change list only")
+    a = ap.parse_args()
+
+    oldrev = a.oldrev
+    if a.merge_base:
+        oldrev = git("merge-base", a.oldrev, a.newrev).strip()
+
+    paths = a.paths
+    if a.all or not paths:
+        paths = changed_svgs(oldrev, a.newrev)
+
+    out_dir = (REPO / a.out) if not Path(a.out).is_absolute() else Path(a.out)
+    if not a.no_html and paths:
+        out_dir.mkdir(parents=True, exist_ok=True)
+
+    results = []
+    for path in paths:
+        old_bytes, new_bytes = blob(oldrev, path), blob(a.newrev, path)
+        res = {"path": path, "note": "", "regions": [], "stats": None, "html": None}
+        if old_bytes is None or new_bytes is None:
+            res["note"] = ("added in this change" if old_bytes is None
+                           else "deleted in this change")
+            results.append(res)
+            continue
+        if old_bytes == new_bytes:
+            continue
+        res["regions"], res["stats"] = svg_struct.diff(old_bytes, new_bytes)
+        if not a.no_html:
+            dest = out_dir / f"svgdiff-{Path(path).stem}.html"
+            dest.write_text(
+                build_viewer(Path(path).name, a.oldrev, a.newrev,
+                             old_bytes, new_bytes, res["regions"], res["stats"]),
+                encoding="utf-8")
+            res["html"] = str(dest.relative_to(REPO)) if dest.is_relative_to(REPO) else str(dest)
+        results.append(res)
+
+    render = report_markdown if a.format == "markdown" else report_text
+    text = render(results, a.oldrev, a.newrev)
+    try:
+        print(text)
+    except UnicodeEncodeError:                      # legacy Windows console codepage
+        sys.stdout.buffer.write(text.encode("utf-8", "replace") + b"\n")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/svgdiff/svg_struct.py
+++ b/tools/svgdiff/svg_struct.py
@@ -1,0 +1,219 @@
+"""Structural model of a yEd/SDL-style SVG: nodes, free labels, edges.
+
+Nodes are `<g transform="translate(..) scale(..) translate(..)">` wrapping one
+shape; labels are absolutely-positioned <text>; edges are top-level <path>/<line>.
+Signatures are position-independent, so an auto-layout reflow does not register
+as a change -- only genuinely added/removed content does.
+"""
+import re
+import xml.etree.ElementTree as ET
+from collections import Counter, defaultdict
+
+SVG = "{http://www.w3.org/2000/svg}"
+NUM = re.compile(r"-?\d+(?:\.\d+)?")
+
+
+def _f(el, attr, default=0.0):
+    v = el.get(attr)
+    return float(v) if v not in (None, "") else default
+
+
+def _transform(t):
+    """Return (tx, ty, sx, sy) for 'translate(a b) scale(sx sy) translate(cx cy)'."""
+    tx = ty = 0.0
+    sx = sy = 1.0
+    for kind, body in re.findall(r"(translate|scale)\(([^)]*)\)", t or ""):
+        n = [float(x) for x in NUM.findall(body)]
+        if kind == "translate":
+            a, b = (n + [0.0, 0.0])[:2]
+            tx += sx * a
+            ty += sy * b
+        else:
+            a = n[0]
+            b = n[1] if len(n) > 1 else a
+            sx *= a
+            sy *= b
+    return tx, ty, sx, sy
+
+
+def _shape(el):
+    """(kind, width, height, extra) in the element's own coordinates, plus local origin."""
+    tag = el.tag.replace(SVG, "")
+    if tag == "rect":
+        rx = round(_f(el, "rx"), 1)
+        return tag, _f(el, "width"), _f(el, "height"), f"r{rx}", _f(el, "x"), _f(el, "y")
+    if tag == "ellipse":
+        rx, ry = _f(el, "rx"), _f(el, "ry")
+        return tag, 2 * rx, 2 * ry, "", _f(el, "cx") - rx, _f(el, "cy") - ry
+    if tag == "circle":
+        r = _f(el, "r")
+        return tag, 2 * r, 2 * r, "", _f(el, "cx") - r, _f(el, "cy") - r
+    if tag == "polygon":
+        pts = [float(x) for x in NUM.findall(el.get("points", ""))]
+        xs, ys = pts[0::2], pts[1::2]
+        if not xs:
+            return None
+        # normalise the outline so identical shapes at different sizes still differ,
+        # but identical shapes anywhere match
+        w, h = max(xs) - min(xs), max(ys) - min(ys)
+        norm = " ".join(f"{(x - min(xs)) / (w or 1):.2f},{(y - min(ys)) / (h or 1):.2f}"
+                        for x, y in zip(xs, ys))
+        return tag, w, h, norm, min(xs), min(ys)
+    if tag == "path":
+        pts = [float(x) for x in NUM.findall(el.get("d", ""))]
+        xs, ys = pts[0::2], pts[1::2]
+        if not xs:
+            return None
+        return tag, max(xs) - min(xs), max(ys) - min(ys), "", min(xs), min(ys)
+    return None
+
+
+def _text_of(el):
+    return "".join(el.itertext()).strip()
+
+
+class Model:
+    def __init__(self, svg_bytes):
+        root = ET.fromstring(svg_bytes)
+        vb = [float(x) for x in NUM.findall(root.get("viewBox", "0 0 0 0"))]
+        self.ox, self.oy = vb[0], vb[1]
+        self.width, self.height = vb[2], vb[3]
+        self.nodes, self.edges, self.texts = [], [], []
+        self._walk(root)
+        self._attach_labels()
+
+    def _box(self, x, y, w, h):
+        return [round(x - self.ox, 1), round(y - self.oy, 1), round(w, 1), round(h, 1)]
+
+    def _walk(self, root):
+        for g in root.findall(f"{SVG}g"):
+            tx, ty, sx, sy = _transform(g.get("transform"))
+            sh = None
+            for el in g.iter():
+                sh = _shape(el)
+                if sh:
+                    break
+            if not sh:
+                continue
+            kind, w, h, extra, lx, ly = sh
+            self.nodes.append({
+                "sig": (kind, round(w, 1), round(h, 1), extra),
+                "box": self._box(tx + sx * lx, ty + sy * ly, w * sx, h * sy),
+                "labels": [],
+            })
+        for tag in ("path", "line"):
+            for el in root.findall(f"{SVG}{tag}"):
+                if tag == "line":
+                    pts = [_f(el, "x1"), _f(el, "y1"), _f(el, "x2"), _f(el, "y2")]
+                else:
+                    pts = [float(x) for x in NUM.findall(el.get("d", ""))]
+                if len(pts) < 4:
+                    continue
+                xs, ys = pts[0::2], pts[1::2]
+                self.edges.append({
+                    "a": (xs[0], ys[0]), "b": (xs[-1], ys[-1]),
+                    "dashed": bool(el.get("stroke-dasharray")),
+                    "box": self._box(min(xs), min(ys), max(xs) - min(xs), max(ys) - min(ys)),
+                })
+        for el in root.findall(f"{SVG}text"):
+            t = _text_of(el)
+            if t:
+                self.texts.append({"t": t, "x": _f(el, "x"), "y": _f(el, "y")})
+
+    def _attach_labels(self):
+        """Give each text to the node whose box contains it; the rest are edge labels."""
+        self.free = []
+        for t in self.texts:
+            x, y = t["x"] - self.ox, t["y"] - self.oy
+            owner = None
+            for n in self.nodes:
+                bx, by, bw, bh = n["box"]
+                # inset: a node's own caption sits well inside it, whereas an edge
+                # label often grazes a node's bounding box without belonging to it
+                ix, iy = min(10.0, bw / 4), min(6.0, bh / 4)
+                if bx + ix <= x <= bx + bw - ix and by + iy <= y <= by + bh - iy:
+                    owner = n
+                    break
+            if owner:
+                owner["labels"].append(t["t"])
+            else:
+                self.free.append(t)
+        for n in self.nodes:
+            n["label"] = " ".join(n["labels"])
+            n["sig"] = n["sig"] + (n["label"],)
+
+    def nearest(self, pt):
+        """Label of the node closest to a point (for naming edge endpoints)."""
+        x, y = pt[0] - self.ox, pt[1] - self.oy
+        best, bd = None, 1e18
+        for n in self.nodes:
+            bx, by, bw, bh = n["box"]
+            dx = max(bx - x, 0, x - (bx + bw))
+            dy = max(by - y, 0, y - (by + bh))
+            d = dx * dx + dy * dy
+            if d < bd:
+                best, bd = n, d
+            if d == 0:
+                break
+        if best is None or bd > 60 * 60:
+            return "(unattached)"
+        return (best["label"] or "(unlabelled)")[:60]
+
+    def edge_sigs(self):
+        out = defaultdict(list)
+        for e in self.edges:
+            sig = (self.nearest(e["a"]), self.nearest(e["b"]), e["dashed"])
+            out[sig].append(e)
+        return out
+
+
+def _multidiff(old_items, new_items, key):
+    """Return (added, removed) after cancelling equal-signature pairs."""
+    oc, nc = Counter(key(i) for i in old_items), Counter(key(i) for i in new_items)
+    add_keys, rem_keys = nc - oc, oc - nc
+    added, removed = [], []
+    for items, counts, sink in ((new_items, add_keys, added), (old_items, rem_keys, removed)):
+        left = Counter(counts)
+        for i in items:
+            k = key(i)
+            if left.get(k, 0):
+                left[k] -= 1
+                sink.append(i)
+    return added, removed
+
+
+def diff(old_bytes, new_bytes):
+    o, n = Model(old_bytes), Model(new_bytes)
+    regions = []
+
+    add, rem = _multidiff(o.nodes, n.nodes, lambda x: x["sig"])
+    for src, kind in ((add, "added"), (rem, "removed")):
+        for x in src:
+            regions.append({"kind": kind, "what": "node", "side": "new" if kind == "added" else "old",
+                            "box": x["box"], "text": x["label"] or f'({x["sig"][0]} shape)'})
+
+    add, rem = _multidiff(o.free, n.free, lambda x: x["t"])
+    for src, kind in ((add, "added"), (rem, "removed")):
+        for x in src:
+            regions.append({"kind": kind, "what": "label", "side": "new" if kind == "added" else "old",
+                            "box": [round(x["x"] - (n if kind == "added" else o).ox - 40, 1),
+                                    round(x["y"] - (n if kind == "added" else o).oy - 16, 1), 80.0, 22.0],
+                            "text": x["t"]})
+
+    oe, ne = o.edge_sigs(), n.edge_sigs()
+    for sig in set(ne) - set(oe):
+        for e in ne[sig][:1]:
+            regions.append({"kind": "added", "what": "edge", "side": "new", "box": e["box"],
+                            "text": f"{sig[0]} → {sig[1]}"})
+    for sig in set(oe) - set(ne):
+        for e in oe[sig][:1]:
+            regions.append({"kind": "removed", "what": "edge", "side": "old", "box": e["box"],
+                            "text": f"{sig[0]} → {sig[1]}"})
+
+    order = {"node": 0, "label": 1, "edge": 2}
+    regions.sort(key=lambda r: (order[r["what"]], r["kind"], r["text"]))
+    stats = {
+        "old": {"nodes": len(o.nodes), "edges": len(o.edges), "labels": len(o.free)},
+        "new": {"nodes": len(n.nodes), "edges": len(n.edges), "labels": len(n.free)},
+    }
+    return regions, stats

--- a/tools/svgdiff/viewer_template.html
+++ b/tools/svgdiff/viewer_template.html
@@ -1,0 +1,290 @@
+<!doctype html>
+<meta charset="utf-8">
+<title>SVG diff &mdash; __NAME__</title>
+<style>
+  :root { color-scheme: light; }
+  * { box-sizing: border-box; }
+  body { margin: 0; font: 13px system-ui, sans-serif; background: #1b1d21; color: #e6e6e6; }
+  header { padding: 8px 12px; background: #24262b; border-bottom: 1px solid #3a3d44;
+           display: flex; flex-wrap: wrap; gap: 14px; align-items: center; position: sticky; top: 0; z-index: 5; }
+  .title { font-weight: 600; }
+  .revs { color: #9aa0aa; font-family: ui-monospace, monospace; font-size: 12px; }
+  .group { display: flex; gap: 4px; align-items: center; }
+  button { font: inherit; background: #33363d; color: #e6e6e6; border: 1px solid #474b54;
+           border-radius: 5px; padding: 4px 10px; cursor: pointer; }
+  button:hover { background: #3d414a; }
+  button.on { background: #4b7bd4; border-color: #4b7bd4; color: #fff; }
+  label { color: #9aa0aa; }
+  #layout { display: flex; height: calc(100vh - 46px); }
+  #list { width: 320px; flex: none; overflow: auto; background: #24262b; border-right: 1px solid #3a3d44; }
+  #list .row { padding: 6px 10px; border-bottom: 1px solid #2e3138; cursor: pointer; display: flex; gap: 8px; }
+  #list .row:hover { background: #2e3138; }
+  #list .row.on { background: #34435e; }
+  #list .k { font-family: ui-monospace, monospace; font-size: 11px; flex: none; width: 13px; text-align: center; }
+  #list .added .k { color: #46c46a; } #list .removed .k { color: #ff5d7a; }
+  #list .w { color: #7d838d; font-size: 11px; flex: none; width: 38px; }
+  #list .t { word-break: break-word; }
+  #list .empty { padding: 12px; color: #7d838d; }
+  #stage { position: relative; overflow: auto; flex: 1; background: #fff; }
+  #wrap { position: relative; transform-origin: 0 0; }
+  #wrap canvas { position: absolute; top: 0; left: 0; display: block; }
+  #cOld, #cNew, #cDiff { image-rendering: auto; }
+  #cBox { pointer-events: none; }
+  #status { color: #9aa0aa; margin-left: auto; }
+  .hint { color: #7d838d; }
+</style>
+<header>
+  <span class="title">__NAME__</span>
+  <span class="revs">__OLDREV__ &rarr; __NEWREV__</span>
+  <span class="group">
+    <button data-mode="new" class="on">New</button>
+    <button data-mode="old">Old</button>
+    <button data-mode="swipe">Swipe</button>
+    <button data-mode="onion">Onion</button>
+    <button data-mode="blink">Blink</button>
+    <button data-mode="diff">Difference</button>
+  </span>
+  <span class="group" id="onionCtl" hidden>
+    <label>old <input type="range" id="onion" min="0" max="100" value="50"> new</label>
+  </span>
+  <span class="group">
+    <button id="prev">&larr; prev</button>
+    <button id="next">next change &rarr;</button>
+    <button id="boxes" class="on">Boxes</button>
+    <button id="src" class="on" title="Structural: added/removed nodes, labels and edges, immune to layout reflow. Pixel: raw rendered differences.">Structural</button>
+  </span>
+  <span class="group">
+    <label>zoom</label>
+    <button data-zoom="-1">&minus;</button>
+    <button data-zoom="fit">fit</button>
+    <button data-zoom="1x">1:1</button>
+    <button data-zoom="+1">+</button>
+  </span>
+  <span id="status">rendering&hellip;</span>
+</header>
+<div id="layout">
+<aside id="list"></aside>
+<div id="stage"><div id="wrap">
+  <canvas id="cOld"></canvas><canvas id="cNew"></canvas>
+  <canvas id="cDiff"></canvas><canvas id="cBox"></canvas>
+</div></div>
+</div>
+<script>
+const OLD_SRC = "__OLD__", NEW_SRC = "__NEW__";
+const STRUCT = __STRUCT__, STATS = __STATS__;
+const BLOCK = 4, TOL = 24, GAP = 3;   // px per block, channel tolerance, merge gap in blocks
+const stage = document.getElementById('stage'), wrap = document.getElementById('wrap');
+const cOld = document.getElementById('cOld'), cNew = document.getElementById('cNew');
+const cDiff = document.getElementById('cDiff'), cBox = document.getElementById('cBox');
+const status = document.getElementById('status');
+let W = 0, H = 0, regions = [], pixelRegions = [], cur = -1, mode = 'new', zoom = 1;
+let showBoxes = true, structural = true, blinkTimer = null;
+
+function load(src) {
+  return new Promise((res, rej) => {
+    const im = new Image();
+    im.onload = () => res(im); im.onerror = rej; im.src = src;
+  });
+}
+
+function paint(im) {
+  const c = document.createElement('canvas');
+  c.width = W; c.height = H;
+  const g = c.getContext('2d', { willReadFrequently: true });
+  g.fillStyle = '#fff'; g.fillRect(0, 0, W, H);
+  g.drawImage(im, 0, 0, im.naturalWidth, im.naturalHeight);
+  return c;
+}
+
+function findRegions(a, b) {
+  const bw = Math.ceil(W / BLOCK), bh = Math.ceil(H / BLOCK);
+  const mask = new Uint8Array(bw * bh);
+  for (let y = 0; y < H; y++) {
+    const row = y * W * 4, by = (y / BLOCK) | 0;
+    for (let x = 0; x < W; x++) {
+      const i = row + x * 4;
+      if (Math.abs(a[i] - b[i]) > TOL || Math.abs(a[i+1] - b[i+1]) > TOL || Math.abs(a[i+2] - b[i+2]) > TOL)
+        mask[by * bw + ((x / BLOCK) | 0)] = 1;
+    }
+  }
+  // dilate so nearby changes cluster into one region
+  const dil = new Uint8Array(mask);
+  for (let y = 0; y < bh; y++) for (let x = 0; x < bw; x++) {
+    if (!mask[y * bw + x]) continue;
+    for (let dy = -GAP; dy <= GAP; dy++) for (let dx = -GAP; dx <= GAP; dx++) {
+      const ny = y + dy, nx = x + dx;
+      if (ny >= 0 && ny < bh && nx >= 0 && nx < bw) dil[ny * bw + nx] = 1;
+    }
+  }
+  const seen = new Uint8Array(bw * bh), out = [], stack = [];
+  for (let s = 0; s < dil.length; s++) {
+    if (!dil[s] || seen[s]) continue;
+    let x0 = 1e9, y0 = 1e9, x1 = -1, y1 = -1, n = 0;
+    stack.push(s); seen[s] = 1;
+    while (stack.length) {
+      const p = stack.pop(), px = p % bw, py = (p / bw) | 0;
+      if (mask[p]) n++;
+      if (px < x0) x0 = px; if (px > x1) x1 = px;
+      if (py < y0) y0 = py; if (py > y1) y1 = py;
+      for (let dy = -1; dy <= 1; dy++) for (let dx = -1; dx <= 1; dx++) {
+        const ny = py + dy, nx = px + dx;
+        if (ny < 0 || ny >= bh || nx < 0 || nx >= bw) continue;
+        const q = ny * bw + nx;
+        if (dil[q] && !seen[q]) { seen[q] = 1; stack.push(q); }
+      }
+    }
+    if (n < 2) continue;   // ignore single-block speckle
+    out.push({ x: x0 * BLOCK - 6, y: y0 * BLOCK - 6,
+               w: (x1 - x0 + 1) * BLOCK + 12, h: (y1 - y0 + 1) * BLOCK + 12,
+               kind: 'pixel', what: 'px', side: 'new', text: `${n * BLOCK * BLOCK} px` });
+  }
+  out.sort((p, q) => (p.y - q.y) || (p.x - q.x));
+  return out;
+}
+
+function drawBoxes() {
+  const g = cBox.getContext('2d');
+  g.clearRect(0, 0, W, H);
+  if (!showBoxes) return;
+  const lw = Math.max(2, 2.5 / zoom);
+  const col = { added: '46,196,106', removed: '255,93,122', pixel: '255,45,85' };
+  regions.forEach((r, i) => {
+    const c = col[r.kind] || col.pixel;
+    g.lineWidth = i === cur ? lw * 1.8 : lw;
+    g.strokeStyle = `rgba(${c},${i === cur ? 1 : .5})`;
+    g.strokeRect(r.x, r.y, r.w, r.h);
+    if (i === cur) { g.fillStyle = `rgba(${c},.12)`; g.fillRect(r.x, r.y, r.w, r.h); }
+  });
+}
+
+function applyMode() {
+  clearInterval(blinkTimer); blinkTimer = null;
+  cOld.style.display = cNew.style.display = cDiff.style.display = 'none';
+  cNew.style.clipPath = ''; cOld.style.opacity = cNew.style.opacity = 1;
+  document.getElementById('onionCtl').hidden = mode !== 'onion';
+  if (mode === 'new') cNew.style.display = 'block';
+  else if (mode === 'old') cOld.style.display = 'block';
+  else if (mode === 'diff') cDiff.style.display = 'block';
+  else if (mode === 'swipe') { cOld.style.display = cNew.style.display = 'block'; setSwipe(0.5); }
+  else if (mode === 'onion') {
+    cOld.style.display = cNew.style.display = 'block';
+    cNew.style.opacity = document.getElementById('onion').value / 100;
+  } else if (mode === 'blink') {
+    cOld.style.display = 'block'; cNew.style.display = 'block';
+    let on = true;
+    blinkTimer = setInterval(() => { on = !on; cNew.style.opacity = on ? 1 : 0; }, 600);
+  }
+}
+function setSwipe(f) { cNew.style.clipPath = `inset(0 0 0 ${f * 100}%)`; }
+
+function setZoom(z, anchor) {
+  zoom = Math.max(0.05, Math.min(8, z));
+  wrap.style.transform = `scale(${zoom})`;
+  wrap.style.width = (W * zoom) + 'px'; wrap.style.height = (H * zoom) + 'px';
+  drawBoxes();
+  if (anchor) goto(cur, true);
+}
+function renderList() {
+  const el = document.getElementById('list');
+  if (!regions.length) { el.innerHTML = '<div class="empty">No differences found.</div>'; return; }
+  el.innerHTML = regions.map((r, i) =>
+    `<div class="row ${r.kind}" data-i="${i}"><span class="k">${r.kind === 'removed' ? '−' : '+'}</span>` +
+    `<span class="w">${r.what}</span><span class="t"></span></div>`).join('');
+  [...el.querySelectorAll('.row')].forEach((row, i) => {
+    row.querySelector('.t').textContent = regions[i].text;
+    row.onclick = () => goto(i);
+  });
+}
+
+function goto(i, keep) {
+  if (!regions.length) return;
+  cur = ((i % regions.length) + regions.length) % regions.length;
+  const r = regions[cur];
+  // content that only exists on one side is invisible in the other view
+  if (r.side === 'old' && mode === 'new') setMode('old');
+  else if (r.side === 'new' && mode === 'old') setMode('new');
+  const rows = document.querySelectorAll('#list .row');
+  rows.forEach(x => x.classList.remove('on'));
+  if (rows[cur]) { rows[cur].classList.add('on'); rows[cur].scrollIntoView({ block: 'nearest' }); }
+  stage.scrollLeft = (r.x + r.w / 2) * zoom - stage.clientWidth / 2;
+  stage.scrollTop = (r.y + r.h / 2) * zoom - stage.clientHeight / 2;
+  drawBoxes();
+  if (!keep) status.textContent = `change ${cur + 1} of ${regions.length}`;
+}
+
+function setMode(m) {
+  mode = m;
+  document.querySelectorAll('[data-mode]').forEach(b => b.classList.toggle('on', b.dataset.mode === m));
+  applyMode();
+}
+
+function useSource() {
+  regions = structural ? STRUCT : pixelRegions;
+  cur = -1;
+  renderList(); drawBoxes();
+  status.textContent = structural
+    ? `${STRUCT.length} structural change${STRUCT.length === 1 ? '' : 's'} · ` +
+      `nodes ${STATS.old.nodes}→${STATS.new.nodes}, edges ${STATS.old.edges}→${STATS.new.edges}`
+    : `${pixelRegions.length} changed pixel region${pixelRegions.length === 1 ? '' : 's'}`;
+  if (regions.length) goto(0, true);
+}
+
+(async () => {
+  const [a, b] = await Promise.all([load(OLD_SRC), load(NEW_SRC)]);
+  W = Math.max(a.naturalWidth, b.naturalWidth); H = Math.max(a.naturalHeight, b.naturalHeight);
+  for (const c of [cOld, cNew, cDiff, cBox]) { c.width = W; c.height = H; }
+  const oc = paint(a), nc = paint(b);
+  cOld.getContext('2d').drawImage(oc, 0, 0);
+  cNew.getContext('2d').drawImage(nc, 0, 0);
+  const da = oc.getContext('2d').getImageData(0, 0, W, H).data;
+  const db = nc.getContext('2d').getImageData(0, 0, W, H).data;
+
+  // difference view: faded new render, changed pixels in magenta
+  const dg = cDiff.getContext('2d'), img = dg.createImageData(W, H);
+  for (let i = 0; i < da.length; i += 4) {
+    const changed = Math.abs(da[i] - db[i]) > TOL || Math.abs(da[i+1] - db[i+1]) > TOL || Math.abs(da[i+2] - db[i+2]) > TOL;
+    if (changed) { img.data[i] = 255; img.data[i+1] = 0; img.data[i+2] = 110; img.data[i+3] = 255; }
+    else { const v = 235 + (db[i] >> 4); img.data[i] = img.data[i+1] = img.data[i+2] = Math.min(v, 255); img.data[i+3] = 255; }
+  }
+  dg.putImageData(img, 0, 0);
+
+  pixelRegions = findRegions(da, db);
+  setZoom(Math.min(stage.clientWidth / W, stage.clientHeight / H));
+  applyMode();
+  useSource();
+})();
+
+document.querySelectorAll('[data-mode]').forEach(btn => btn.onclick = () => setMode(btn.dataset.mode));
+document.getElementById('src').onclick = e => {
+  structural = !structural;
+  e.target.classList.toggle('on', structural);
+  e.target.textContent = structural ? 'Structural' : 'Pixel';
+  useSource();
+};
+document.querySelectorAll('[data-zoom]').forEach(btn => btn.onclick = () => {
+  const z = btn.dataset.zoom;
+  if (z === 'fit') setZoom(Math.min(stage.clientWidth / W, stage.clientHeight / H), true);
+  else if (z === '1x') setZoom(1, true);
+  else setZoom(zoom * (z === '+1' ? 1.4 : 1 / 1.4), true);
+});
+document.getElementById('onion').oninput = e => { cNew.style.opacity = e.target.value / 100; };
+document.getElementById('next').onclick = () => goto(cur + 1);
+document.getElementById('prev').onclick = () => goto(cur - 1);
+document.getElementById('boxes').onclick = e => {
+  showBoxes = !showBoxes; e.target.classList.toggle('on', showBoxes); drawBoxes();
+};
+stage.addEventListener('mousemove', e => {
+  if (mode !== 'swipe') return;
+  const r = stage.getBoundingClientRect();
+  setSwipe(Math.max(0, Math.min(1, (e.clientX - r.left + stage.scrollLeft) / (W * zoom))));
+});
+stage.addEventListener('wheel', e => {
+  if (!e.ctrlKey) return;
+  e.preventDefault(); setZoom(zoom * (e.deltaY < 0 ? 1.15 : 1 / 1.15), true);
+}, { passive: false });
+addEventListener('keydown', e => {
+  if (e.key === 'n') goto(cur + 1);
+  else if (e.key === 'p') goto(cur - 1);
+  else if (e.key >= '1' && e.key <= '6') document.querySelectorAll('[data-mode]')[+e.key - 1].click();
+});
+</script>


### PR DESCRIPTION
Reviewing a figure change by eye is currently impractical. The `svg/` renders are auto-laid-out, so adding a single node reflows the whole page — on #81, which splices one decision diamond into two figures, a rendered image diff reports **~55 changed regions**, the largest spanning half the diagram, because nearly every edge shifts by a few pixels. Off-the-shelf image-diff tools (ImageMagick `compare`, `pixelmatch`, GitHub's own swipe/onion-skin) all hit the same wall.

`tools/svgdiff/svg_diff.py` diffs the **structure** instead. The renderer emits each node as a `<g transform="translate(..)">` wrapping one shape, so a node can be given a position-independent signature (shape + dimensions + label), an edge a signature of *(source label → target label)*, and a free label its text. Diffing those as multisets makes layout movement cancel out, leaving only genuinely added or removed content.

Run against #81, the same change reduces to seven findings that read as a sentence — the `N(s) == V(r)?` **No** branch now goes through a window check, whose **No** side discards the frame:

```
spec-sdl/v2.2-errata/data-link/svg/DataLink_Connected.svg
  + node   V(r) < N(s) < V(r) + k?
  + label  No
  + label  Yes
  + edge   N(s) == V(r)? → V(r) < N(s) < V(r) + k?
  + edge   V(r) < N(s) < V(r) + k? → Discard Contents of I Frame
  + edge   V(r) < N(s) < V(r) + k? → Reject Exception?
  − edge   N(s) == V(r)? → Reject Exception?
```

## What's in it

- **`svg_struct.py`** — parses a render into nodes / edges / free labels and diffs the signatures. Node counts come out as a sanity check (181→182, edges 209→211).
- **`svg_diff.py`** — the CLI.
- **`viewer_template.html`** — a self-contained HTML viewer, written per figure with both renders embedded as data URIs. No network, no dependencies, opens straight from disk. New / Old / Swipe / Onion-skin / Blink / Difference views, plus a clickable change list down the side that zooms to each change and flips to the old render for removed content. It also computes a raw pixel diff in-browser, kept behind a Structural ⇄ Pixel toggle for the cases where a purely cosmetic render change needs checking.

## Usage

```sh
# every SVG that differs on a branch, against the point it forked from
python3 tools/svgdiff/svg_diff.py main my-branch --all --merge-base

# just the change list, as a table for a PR comment
python3 tools/svgdiff/svg_diff.py main my-branch --all --merge-base --format markdown --no-html
```

Viewers land in the now-gitignored `build/svgdiff/`. Stdlib Python only — no new CI dependency, and `--format markdown --no-html` is ready to drop into a workflow that posts the change list on any PR touching `spec-sdl/**/svg/`. I have not added that workflow here; happy to follow up with it if you want it.

## Verification

Exercised against #81 (both figures), a pure-reflow case, an added-file case, and a no-change case; the generated viewers were rendered in headless Chrome to confirm the change list, the zoom-to-change navigation and the old/new flip all behave.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188JcqNg5JDQqdsBt7LrbyE
