### PR TITLE
ci: post the figure change list on PRs that touch an SVG

### DIFF
--- a/.github/workflows/svg-figure-diff.yml
+++ b/.github/workflows/svg-figure-diff.yml
@@ -110,8 +110,11 @@ jobs:
           } > body.md
           # Sticky: rewrite our own comment in place rather than stacking a new
           # one on every push. Matched by the marker, not by author.
+          # awk, not `head -n1`: head closes the pipe early, which under
+          # `set -o pipefail` turns a multi-page listing into a SIGPIPE failure.
           id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
-                 --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
+                 --jq ".[] | select(.body | startswith(\"$marker\")) | .id" \
+               | awk 'NR == 1')
           if [ -n "$id" ]; then
             jq -Rs '{body: .}' body.md > payload.json
             gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" --input payload.json > /dev/null

--- a/.github/workflows/svg-figure-diff.yml
+++ b/.github/workflows/svg-figure-diff.yml
@@ -1,0 +1,125 @@
+name: svg figure diff
+
+# ─── Posts the structural change list for every figure a PR touches, so a
+#     reviewer does not have to spot a one-diamond change by eye in a 5500px
+#     auto-laid-out render. See tools/svgdiff/ and the README section
+#     "Reviewing a figure change". This is a reviewer aid, never a gate: it
+#     reports, it does not fail the PR. The drift gates live in ci.yml.
+#
+#     Fires on PRs that change an SVG. workflow_dispatch takes a PR number so
+#     the report can be regenerated on demand for a PR opened before this
+#     workflow existed, or re-run after the tool changes.
+#
+#     Fork PRs get a read-only token, so the change list goes to the job
+#     summary for those; same-repo PRs additionally get a sticky comment.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '**.svg'
+  workflow_dispatch:
+    inputs:
+      pr:
+        description: PR number to report on
+        required: true
+
+concurrency:
+  group: svg-figure-diff-${{ github.event.pull_request.number || inputs.pr }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  svg-figure-diff:
+    name: svg figure diff
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write
+    steps:
+      # Full history: the report compares the PR head against the point the
+      # branch forked from, which needs the merge base to be reachable.
+      - uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      - name: resolve the revisions to compare
+        id: revs
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EVENT: ${{ github.event_name }}
+          INPUT_PR: ${{ inputs.pr }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_BASE: ${{ github.event.pull_request.base.sha }}
+          PR_HEAD: ${{ github.event.pull_request.head.sha }}
+          SAME_REPO: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+        run: |
+          set -euo pipefail
+          if [ "$EVENT" = workflow_dispatch ]; then
+            pr="$INPUT_PR"
+            # The head of a dispatched PR is not part of this checkout yet.
+            git fetch -q origin "refs/pull/$pr/head"
+            base=$(gh pr view "$pr" --json baseRefOid --jq .baseRefOid)
+            head=$(gh pr view "$pr" --json headRefOid --jq .headRefOid)
+            same=$(gh pr view "$pr" --json isCrossRepository --jq 'if .isCrossRepository then "false" else "true" end')
+          else
+            pr="$PR_NUMBER"; base="$PR_BASE"; head="$PR_HEAD"; same="$SAME_REPO"
+          fi
+          {
+            echo "pr=$pr"
+            echo "base=$base"
+            echo "head=$head"
+            echo "same_repo=$same"
+          } >> "$GITHUB_OUTPUT"
+          echo "PR #$pr: $base..$head (same-repo: $same)"
+
+      # Writes report.md plus one self-contained HTML viewer per changed
+      # figure into build/svgdiff/. Python stdlib only — no setup step.
+      - name: diff the changed figures
+        run: |
+          set -euo pipefail
+          python3 tools/svgdiff/svg_diff.py \
+            "${{ steps.revs.outputs.base }}" "${{ steps.revs.outputs.head }}" \
+            --all --merge-base --format markdown > report.md
+          cat report.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: upload the interactive viewers
+        uses: actions/upload-artifact@v4
+        with:
+          name: svg-figure-diff-${{ steps.revs.outputs.pr }}
+          path: build/svgdiff/*.html
+          if-no-files-found: ignore
+          retention-days: 30
+
+      - name: post the change list on the PR
+        if: steps.revs.outputs.same_repo == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR: ${{ steps.revs.outputs.pr }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          set -euo pipefail
+          marker='<!-- svg-figure-diff -->'
+          {
+            printf '%s\n' "$marker"
+            cat report.md
+            printf '\nInteractive viewers — swipe, onion-skin, blink, and a clickable change list that zooms to each change — are attached to [this run](%s) as the `svg-figure-diff` artifact: download, unzip, open the HTML.\n' "$RUN_URL"
+            printf '\n<sub>Locally: `python3 tools/svgdiff/svg_diff.py main HEAD --all --merge-base`</sub>\n'
+          } > body.md
+          # Sticky: rewrite our own comment in place rather than stacking a new
+          # one on every push. Matched by the marker, not by author.
+          id=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR/comments" --paginate \
+                 --jq ".[] | select(.body | startswith(\"$marker\")) | .id" | head -n1)
+          if [ -n "$id" ]; then
+            jq -Rs '{body: .}' body.md > payload.json
+            gh api -X PATCH "repos/$GITHUB_REPOSITORY/issues/comments/$id" --input payload.json > /dev/null
+            echo "updated comment $id"
+          else
+            gh pr comment "$PR" --body-file body.md
+          fi
+
+      - name: note that fork PRs cannot be commented on
+        if: steps.revs.outputs.same_repo != 'true'
+        run: echo "::notice::Fork PR — the figure change list is in this run's job summary; the read-only token cannot post a comment."

--- a/tools/svgdiff/svg_diff.py
+++ b/tools/svgdiff/svg_diff.py
@@ -33,6 +33,7 @@ import argparse
 import base64
 import html
 import json
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -89,6 +90,11 @@ def build_viewer(name: str, oldrev: str, newrev: str,
 SIGN = {"added": "+", "removed": "−"}
 
 
+def short(rev: str) -> str:
+    """Abbreviate a full object name; leave branch and tag names alone."""
+    return rev[:8] if re.fullmatch(r"[0-9a-f]{40}", rev) else rev
+
+
 def report_text(results: list[dict], oldrev: str, newrev: str) -> str:
     lines = []
     for res in results:
@@ -102,14 +108,14 @@ def report_text(results: list[dict], oldrev: str, newrev: str) -> str:
         if res["html"]:
             lines.append(f"  viewer: {res['html']}")
     if not results:
-        lines.append(f"no SVG differs between {oldrev} and {newrev}")
+        lines.append(f"no SVG differs between {short(oldrev)} and {short(newrev)}")
     return "\n".join(lines).lstrip("\n")
 
 
 def report_markdown(results: list[dict], oldrev: str, newrev: str) -> str:
     if not results:
-        return f"No SVG figure differs between `{oldrev}` and `{newrev}`."
-    out = [f"### SVG figure changes (`{oldrev}` → `{newrev}`)", ""]
+        return f"No SVG figure differs between `{short(oldrev)}` and `{short(newrev)}`."
+    out = [f"### SVG figure changes (`{short(oldrev)}` → `{short(newrev)}`)", ""]
     for res in results:
         out.append(f"**`{res['path']}`**")
         if res["note"]:
@@ -153,8 +159,12 @@ def main() -> int:
     a = ap.parse_args()
 
     oldrev = a.oldrev
+    old_label = a.oldrev
     if a.merge_base:
         oldrev = git("merge-base", a.oldrev, a.newrev).strip()
+        named = git("rev-parse", a.oldrev).strip()
+        old_label = (short(oldrev) if oldrev == named
+                     else f"{short(oldrev)} (merge base with {short(a.oldrev)})")
 
     paths = a.paths
     if a.all or not paths:
@@ -179,14 +189,14 @@ def main() -> int:
         if not a.no_html:
             dest = out_dir / f"svgdiff-{Path(path).stem}.html"
             dest.write_text(
-                build_viewer(Path(path).name, a.oldrev, a.newrev,
+                build_viewer(Path(path).name, old_label, short(a.newrev),
                              old_bytes, new_bytes, res["regions"], res["stats"]),
                 encoding="utf-8")
             res["html"] = str(dest.relative_to(REPO)) if dest.is_relative_to(REPO) else str(dest)
         results.append(res)
 
     render = report_markdown if a.format == "markdown" else report_text
-    text = render(results, a.oldrev, a.newrev)
+    text = render(results, old_label, a.newrev)
     try:
         print(text)
     except UnicodeEncodeError:                      # legacy Windows console codepage


### PR DESCRIPTION
Follow-up to #82, which added `tools/svgdiff/`. This wires it into CI so the change list appears on the PR automatically.

Fires on `pull_request` matching `'**.svg'`, exactly as asked — a PR that touches no SVG never runs it.

## What a reviewer sees

The change list lands in the job summary and, for same-repo PRs, in a comment. Run against #81 it produces:

### SVG figure changes (`abd46b05` → `300b01d5`)

**`spec-sdl/v2.2-errata/data-link/svg/DataLink_Connected.svg`**

nodes 181→182, edges 209→211, labels 71→73

| | what | change |
| --- | --- | --- |
| + | node | `V(r) < N(s) < V(r) + k?` |
| + | label | `No` |
| + | label | `Yes` |
| + | edge | `N(s) == V(r)? → V(r) < N(s) < V(r) + k?` |
| + | edge | `V(r) < N(s) < V(r) + k? → Discard Contents of I Frame` |
| + | edge | `V(r) < N(s) < V(r) + k? → Reject Exception?` |
| − | edge | `N(s) == V(r)? → Reject Exception?` |

…plus the same for `DataLink_TimerRecovery.svg`, and a link to the run's artifact holding the interactive viewers.

## Design notes

- **Reviewer aid, not a gate.** It reports and never fails the PR. The drift gates stay in `ci.yml`; this is a separate workflow so the `paths` filter and the `pull-requests: write` scope stay off them.
- **Sticky comment.** Matched by an HTML marker rather than by author, so pushes rewrite the comment in place instead of stacking one per push.
- **Fork PRs** get a read-only token and cannot be commented on. They still get the job summary and the artifact; the workflow emits a `::notice::` saying so rather than failing.
- **Permissions** are scoped on the job, leaving the workflow default at `contents: read`.
- **No setup step** — the tool is stdlib Python, and the runner already has `python3`, `gh` and `jq`.
- **`fetch-depth: 0`** because the report compares against the fork point, which needs the merge base reachable.
- **`workflow_dispatch`** takes a PR number, so the report can be generated for a PR opened before this workflow existed — #81 — or re-run after the tool changes. That path fetches `refs/pull/N/head`, which a normal checkout does not have.

## Also here

`svg_diff.py` now abbreviates full object names in the report and viewer headers, and under `--merge-base` reports the revision actually compared rather than the tip that was named. A 40-character sha twice in a heading is unreadable in a comment. The three header cases:

```
### SVG figure changes (`abd46b05` → `300b01d5`)                        # base is the fork point
### SVG figure changes (`abd46b05 (merge base with main)` → `300b01d5`) # base has moved on
### SVG figure changes (`main` → `300b01d5`)                            # no --merge-base
```

## Verification

The YAML parses and every step's logic was dry-run locally against #81's actual base/head shas: revision resolution, the diff invocation, `report.md`, viewer generation, and the `gh api` sticky-comment lookup (correctly reports no existing comment, i.e. would create rather than patch). The end-to-end run on a real trigger has not happened yet, since this PR touches no SVG and the workflow does not exist on `main` until it merges. Once merged I can confirm it with `workflow_dispatch` against #81 — that is what the dispatch input is there for.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188JcqNg5JDQqdsBt7LrbyE
