### PR TITLE
ci: bump actions/upload-artifact v4 → v7

### DIFF
--- a/.github/workflows/svg-figure-diff.yml
+++ b/.github/workflows/svg-figure-diff.yml
@@ -86,7 +86,7 @@ jobs:
           cat report.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: upload the interactive viewers
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: svg-figure-diff-${{ steps.revs.outputs.pr }}
           path: build/svgdiff/*.html


### PR DESCRIPTION
The first real run of the new `svg figure diff` workflow ([run 34388886264](https://github.com/packethacking/ax25spec/actions/runs/34388886264)) succeeded but carried a deprecation annotation:

> Node.js 20 is deprecated. The following actions target Node.js 20 but are being forced to run on Node.js 24: `actions/upload-artifact@v4`

`upload-artifact` is on v7 now. The four inputs this workflow uses — `name`, `path`, `if-no-files-found`, `retention-days` — are all present and unchanged in v7's `action.yml`, so it's a straight version bump with no call-site change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188JcqNg5JDQqdsBt7LrbyE