### PR TITLE
fix(svgdiff): locate label changes correctly — right instance, right owner

### DIFF
--- a/tools/svgdiff/svg_struct.py
+++ b/tools/svgdiff/svg_struct.py
@@ -141,8 +141,11 @@ class Model:
         for n in self.nodes:
             n["label"] = " ".join(n["labels"])
             n["sig"] = n["sig"] + (n["label"],)
+        # Anchoring needs the node labels above, so it is a second pass.
+        for t in self.free:
+            t["anchor"] = self.nearest((t["x"], t["y"]), max_dist=220)
 
-    def nearest(self, pt):
+    def nearest(self, pt, max_dist=60):
         """Label of the node closest to a point (for naming edge endpoints)."""
         x, y = pt[0] - self.ox, pt[1] - self.oy
         best, bd = None, 1e18
@@ -155,7 +158,7 @@ class Model:
                 best, bd = n, d
             if d == 0:
                 break
-        if best is None or bd > 60 * 60:
+        if best is None or bd > max_dist * max_dist:
             return "(unattached)"
         return (best["label"] or "(unlabelled)")[:60]
 
@@ -167,19 +170,31 @@ class Model:
         return out
 
 
-def _multidiff(old_items, new_items, key):
-    """Return (added, removed) after cancelling equal-signature pairs."""
-    oc, nc = Counter(key(i) for i in old_items), Counter(key(i) for i in new_items)
-    add_keys, rem_keys = nc - oc, oc - nc
-    added, removed = [], []
-    for items, counts, sink in ((new_items, add_keys, added), (old_items, rem_keys, removed)):
-        left = Counter(counts)
-        for i in items:
-            k = key(i)
-            if left.get(k, 0):
-                left[k] -= 1
-                sink.append(i)
-    return added, removed
+def _multidiff(old_items, new_items, *keys):
+    """Return (added, removed) after cancelling old/new pairs.
+
+    Each key in turn is one cancellation pass, finest first. A fine key (a
+    label's text *and* the node it sits by) picks the right instance to
+    report; a coarser fallback (the text alone) still cancels an item whose
+    anchor merely moved, so a reflow cannot invent an add/remove pair.
+    Matching by the coarse key alone would keep the counts right but report
+    an arbitrary instance -- and so point the reviewer at the wrong place.
+    """
+    old_left, new_left = list(old_items), list(new_items)
+    for key in keys:
+        buckets = defaultdict(list)
+        for i in old_left:
+            buckets[key(i)].append(i)
+        matched, survivors = set(), []
+        for i in new_left:
+            bucket = buckets.get(key(i))
+            if bucket:
+                matched.add(id(bucket.pop()))
+            else:
+                survivors.append(i)
+        new_left = survivors
+        old_left = [i for i in old_left if id(i) not in matched]
+    return new_left, old_left
 
 
 def diff(old_bytes, new_bytes):
@@ -192,13 +207,15 @@ def diff(old_bytes, new_bytes):
             regions.append({"kind": kind, "what": "node", "side": "new" if kind == "added" else "old",
                             "box": x["box"], "text": x["label"] or f'({x["sig"][0]} shape)'})
 
-    add, rem = _multidiff(o.free, n.free, lambda x: x["t"])
+    add, rem = _multidiff(o.free, n.free,
+                          lambda x: (x["t"], x["anchor"]), lambda x: x["t"])
     for src, kind in ((add, "added"), (rem, "removed")):
         for x in src:
             regions.append({"kind": kind, "what": "label", "side": "new" if kind == "added" else "old",
                             "box": [round(x["x"] - (n if kind == "added" else o).ox - 40, 1),
                                     round(x["y"] - (n if kind == "added" else o).oy - 16, 1), 80.0, 22.0],
-                            "text": x["t"]})
+                            "text": (f'{x["t"]}  (by {x["anchor"]})'
+                                     if x["anchor"] != "(unattached)" else x["t"])})
 
     oe, ne = o.edge_sigs(), n.edge_sigs()
     for sig in set(ne) - set(oe):

--- a/tools/svgdiff/svg_struct.py
+++ b/tools/svgdiff/svg_struct.py
@@ -5,6 +5,7 @@ shape; labels are absolutely-positioned <text>; edges are top-level <path>/<line
 Signatures are position-independent, so an auto-layout reflow does not register
 as a change -- only genuinely added/removed content does.
 """
+import math
 import re
 import xml.etree.ElementTree as ET
 from collections import Counter, defaultdict
@@ -36,18 +37,43 @@ def _transform(t):
     return tx, ty, sx, sy
 
 
+def _ellipse_ring(cx, cy, rx, ry, steps=32):
+    return [(cx + rx * math.cos(2 * math.pi * k / steps),
+             cy + ry * math.sin(2 * math.pi * k / steps)) for k in range(steps)]
+
+
+def _inside(pt, ring):
+    """Ray-cast point-in-polygon."""
+    x, y = pt
+    inside = False
+    n = len(ring)
+    for i in range(n):
+        ax, ay = ring[i]
+        bx, by = ring[(i - 1) % n]
+        if (ay > y) != (by > y) and x < (bx - ax) * (y - ay) / ((by - ay) or 1e-12) + ax:
+            inside = not inside
+    return inside
+
+
 def _shape(el):
-    """(kind, width, height, extra) in the element's own coordinates, plus local origin."""
+    """(kind, width, height, extra, x, y, ring) in the element's own coordinates.
+
+    `ring` is the ordered outline. A bounding box over-claims a diamond's
+    corners by nearly half the node's width, which is exactly where edge
+    labels sit, so label ownership has to test the real outline.
+    """
     tag = el.tag.replace(SVG, "")
     if tag == "rect":
         rx = round(_f(el, "rx"), 1)
-        return tag, _f(el, "width"), _f(el, "height"), f"r{rx}", _f(el, "x"), _f(el, "y")
+        x, y = _f(el, "x"), _f(el, "y")
+        w, h = _f(el, "width"), _f(el, "height")
+        return tag, w, h, f"r{rx}", x, y, [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
     if tag == "ellipse":
-        rx, ry = _f(el, "rx"), _f(el, "ry")
-        return tag, 2 * rx, 2 * ry, "", _f(el, "cx") - rx, _f(el, "cy") - ry
+        cx, cy, rx, ry = _f(el, "cx"), _f(el, "cy"), _f(el, "rx"), _f(el, "ry")
+        return tag, 2 * rx, 2 * ry, "", cx - rx, cy - ry, _ellipse_ring(cx, cy, rx, ry)
     if tag == "circle":
-        r = _f(el, "r")
-        return tag, 2 * r, 2 * r, "", _f(el, "cx") - r, _f(el, "cy") - r
+        cx, cy, r = _f(el, "cx"), _f(el, "cy"), _f(el, "r")
+        return tag, 2 * r, 2 * r, "", cx - r, cy - r, _ellipse_ring(cx, cy, r, r)
     if tag == "polygon":
         pts = [float(x) for x in NUM.findall(el.get("points", ""))]
         xs, ys = pts[0::2], pts[1::2]
@@ -58,13 +84,17 @@ def _shape(el):
         w, h = max(xs) - min(xs), max(ys) - min(ys)
         norm = " ".join(f"{(x - min(xs)) / (w or 1):.2f},{(y - min(ys)) / (h or 1):.2f}"
                         for x, y in zip(xs, ys))
-        return tag, w, h, norm, min(xs), min(ys)
+        return tag, w, h, norm, min(xs), min(ys), list(zip(xs, ys))
     if tag == "path":
         pts = [float(x) for x in NUM.findall(el.get("d", ""))]
         xs, ys = pts[0::2], pts[1::2]
         if not xs:
             return None
-        return tag, max(xs) - min(xs), max(ys) - min(ys), "", min(xs), min(ys)
+        # A path's ring falls back to its box: the numbers in `d` cannot be paired
+        # into vertices without a full path parser, and H/V/A make that non-trivial.
+        x0, y0, x1, y1 = min(xs), min(ys), max(xs), max(ys)
+        return (tag, x1 - x0, y1 - y0, "", x0, y0,
+                [(x0, y0), (x1, y0), (x1, y1), (x0, y1)])
     return None
 
 
@@ -95,10 +125,12 @@ class Model:
                     break
             if not sh:
                 continue
-            kind, w, h, extra, lx, ly = sh
+            kind, w, h, extra, lx, ly, ring = sh
             self.nodes.append({
                 "sig": (kind, round(w, 1), round(h, 1), extra),
                 "box": self._box(tx + sx * lx, ty + sy * ly, w * sx, h * sy),
+                "ring": [(tx + sx * px - self.ox, ty + sy * py - self.oy)
+                         for px, py in ring],
                 "labels": [],
             })
         for tag in ("path", "line"):
@@ -131,7 +163,12 @@ class Model:
                 # inset: a node's own caption sits well inside it, whereas an edge
                 # label often grazes a node's bounding box without belonging to it
                 ix, iy = min(10.0, bw / 4), min(6.0, bh / 4)
-                if bx + ix <= x <= bx + bw - ix and by + iy <= y <= by + bh - iy:
+                if not (bx + ix <= x <= bx + bw - ix and by + iy <= y <= by + bh - iy):
+                    continue
+                # ...and on a diamond the inset box still over-claims the corners,
+                # which is where edge labels sit. Confirm against the real outline.
+                # Strictly narrowing: this can only reject a claim, never add one.
+                if _inside((x, y), n["ring"]):
                     owner = n
                     break
             if owner:


### PR DESCRIPTION
Two related defects in how `svg_struct` handles labels, both reported by @M0LTE against the #81 report.

## 1. The wrong instance was reported

The `+ label No` / `+ label Yes` findings were highlighted at **Peer Receiver Busy?**, on both figures — a decision the change never touches. The GraphML there is correct and the labels have not swapped.

Free labels were cancelled between old and new by their **text alone**. On a figure with dozens of `Yes`/`No` branch labels that gets the *count* right — one more `Yes`, one more `No`, genuinely added by the new diamond — but `_multidiff` then reports whichever `Yes` comes first in document order. The finding was real; the **location** was arbitrary.

Labels now carry an anchor: the nearest node's label. Matching runs as successive cancellation passes, finest key first:

1. `(text, anchor)` — picks the right *instance* to report.
2. `text` alone — still cancels a label whose anchor merely moved, so a reflow cannot invent a spurious add/remove pair.

Keeping only the coarse key is what caused the bug; keeping only the fine key would trade it for false positives whenever reflow moved a label nearer a different node. Both passes are needed. The anchor now shows in the change list, so a bare `Yes` says where to look:

```
  + node   V(r) < N(s) < V(r) + k?
  + label  No  (by Discard Contents of I Frame)
  + label  Yes  (by V(r) < N(s) < V(r) + k?)
```

## 2. The wrong node could own it

Surfaced while preparing #86. A text was treated as a node's caption when it fell inside the node's **bounding box** less a small inset. On a diamond that box over-claims the corners by nearly half the node's width — again, exactly where branch labels sit. Because the caption forms part of the node signature, one label drifting across that boundary reported the node as removed *and* re-added, and dragged every edge naming it into the diff too.

Nodes now carry their outline, built from the shape the renderer drew: polygon points as-is, rectangles as their corners, ellipses and circles sampled. Ownership keeps the existing inset box as a cheap reject and then confirms against the outline, so the test is **strictly narrowing** — it can only reject a claim the box test used to make, never add one.

## Verification

#86 is an ideal test case: it moves every edge endpoint but alters nothing structural, so **every finding it produces is false**.

| | findings on #86 | worst figure |
| --- | --- | --- |
| before | 28 | 14 |
| after | **13** | **4** |

The findings for #81 are unchanged — the same seven per figure, now pointing at the right places, confirmed in the rendered viewer with the green boxes on the new diamond's own exits and nothing at Peer Receiver Busy?.

## Known limitation

A path-shaped node still falls back to its box, since the numbers in `d` cannot be paired into vertices without a real path parser (`H`, `V` and `A` make that non-trivial). That leaves one false pair on `DataLink_TimerRecovery.srej-received.svg`, where a glyph node drawn as a path claims a nearby `No`. It predates this change and accounts for part of the residual 13.

Once this lands I'll re-dispatch the workflow at #81 so the sticky comment there is corrected in place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188JcqNg5JDQqdsBt7LrbyE
