### PR TITLE
fix(render): clip edges to the node outline, not its bounding box

### DIFF
--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_AwaitingConnection.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_AwaitingConnection.svg
@@ -1,8 +1,8 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="3484.77" height="1681.77" viewBox="-344.37 -506.65 3484.77 1681.77" font-family="Helvetica, Arial, sans-serif">
 <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 1 L 9 5 L 0 9 z" fill="#000000"/></marker></defs>
 <rect x="-344.37" y="-506.65" width="3484.77" height="1681.77" fill="#FFFFFF"/>
-<path d="M 1670.62 -431.51 L -204.37 354.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1670.62 -428.78 L -9.37 351.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1679.71 -435.31 L -204.37 354.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1681.52 -433.85 L -14.64 353.83" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -69.37 415.2 L -69.37 464.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -69.37 524.87 L -69.37 559.75" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -69.37 631.65 L -69.37 666.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -12,14 +12,14 @@
 <path d="M 88.77 646.27 L 88.77 698.77" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 88.77 758.77 L 88.77 798.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 88.77 858.24 L 88.77 910.5" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1671.7 -426.65 L 148.77 348.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 148.77 494.91 L 217.45 698.77" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="169.24" y="559.87" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1681.23 -426.65 L 413.71 343.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1683.19 -432.5 L 145.14 350.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 148.75 494.88 L 217.45 698.77" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="169.23" y="559.84" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1687.06 -430.19 L 413.71 343.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 354.53 415.2 L 354.53 447.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 274.94 656.27 L 247.17 698.77" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 294.55 542.52 L 294.55 596.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="289.55" y="573.26" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 294.55 494.88 L 294.55 596.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="280.55" y="549.78" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 447.53 620.18 L 447.53 620.18" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="447.53" y="624.38" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 447.53 667.83 L 447.53 724.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -29,12 +29,12 @@
 <path d="M 450.47 1040.12 L 450.47 1095.12" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 507.53 620.18 L 644.2 620.18 L 644.2 620.18" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="522.18" y="624.38" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 584.2 754.56 L 502.15 834.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="566.87" y="775.69" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 584.2 754.55 L 502.15 834.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="566.88" y="775.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 644.2 802.2 L 644.2 848.94" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="644.2" y="826.52" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 644.2 949.94 L 644.2 969.59 L 532.42 969.59 L 532.42 694.39 L 465.22 694.39 L 456.35 724.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1698.55 -426.65 L 832.63 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1698.79 -426.87 L 832.63 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 794.2 455.12 L 794.2 492.23" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 794.2 660.1 L 794.2 660.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="794.2" y="664.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
@@ -56,17 +56,17 @@
 <path d="M 1535.26 455.12 L 1535.26 508.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1535.26 580.06 L 1535.26 619.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1729.43 -426.65 L 1697.15 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1719.57 455.12 L 1746.99 496.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1719.57 455.12 L 1757.89 512.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1778.6 591.76 L 1778.6 591.76" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1748.6" y="625.72" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes (Note: assumed; missing from spec)</text>
-<path d="M 1838.6 544.13 L 1877.8 599.47 L 1877.8 766.67 L 1833.86 787.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1843.51" y="607.17" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No (Note: assumed; missing from spec)</text>
+<path d="M 1838.59 544.11 L 1877.8 599.47 L 1877.8 766.67 L 1827.6 791.03" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1843.5" y="607.16" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No (Note: assumed; missing from spec)</text>
 <path d="M 1777.09 728.49 L 1782.35 787.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1741.14 -426.65 L 2025.08 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2037.68 455.12 L 2037.68 514.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2211.52 455.12 L 2211.52 514.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2211.52 574.11 L 2211.52 633.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2151.52 680.75 L 2121.52 693.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2151.52 680.75 L 2112.68 697.54" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="2135.63" y="691.82" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2092.25 753.07 L 2141.26 823.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2161.99 853.98 L 2161.99 853.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -78,7 +78,7 @@
 <path d="M 2577.12 455.12 L 2577.12 508.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2577.12 568.95 L 2577.12 633.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1759.62 -426.65 L 2542.37 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1765.1 -426.65 L 2695.91 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1764.6 -427.08 L 2695.91 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2737.23 568.95 L 2737.23 633.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2737.23 455.12 L 2737.23 508.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2897.35 455.12 L 2897.35 508.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -87,10 +87,10 @@
 <path d="M 3060.4 455.12 L 3060.4 508.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3060.4 568.95 L 3060.4 621.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3060.4 693.09 L 3060.4 732.18" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1770.59 -426.65 L 2849.46 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1776.17 -426.65 L 3005.82 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1768.75 -428.02 L 2849.46 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1772.3 -429.2 L 3005.82 383.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1735.3 -426.65 L 1735.3 -426.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1859.5 460.45 L 1824.68 496.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1859.5 460.45 L 1804.66 517.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <g transform="translate(1670.62 -486.65) scale(1.02 1.03) translate(-1 -1)" style="stroke-width:0.97"><g fill="#FFFFFF" stroke="#000000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="butt">
     <rect x="1.0" y="1.0" width="118" height="58" rx="30.0" ry="30.0" />
   </g>

--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_AwaitingRelease.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_AwaitingRelease.svg
@@ -1,7 +1,7 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="2767.33" height="1417.26" viewBox="-664.33 -285.89 2767.33 1417.26" font-family="Helvetica, Arial, sans-serif">
 <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 1 L 9 5 L 0 9 z" fill="#000000"/></marker></defs>
 <rect x="-664.33" y="-285.89" width="2767.33" height="1417.26" fill="#FFFFFF"/>
-<path d="M 675.22 -208.48 L -524.33 339.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 685.83 -213.33 L -524.33 339.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 708.64 -205.89 L 232.85 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 718.14 -205.89 L 412.47 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 727.64 -205.89 L 592.08 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -9,23 +9,23 @@
 <path d="M 744.86 -205.89 L 917.45 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 754.22 -205.89 L 1094.24 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 762.87 -205.89 L 1257.86 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 771.53 -205.89 L 1421.49 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 781.14 -205.89 L 1602.98 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 790.22 -205.89 L 1780.5 334.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 795.22 -207.8 L 1963 338.91" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 770.79 -206.51 L 1421.49 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 777.08 -208.54 L 1602.98 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 781.3 -210.76 L 1780.5 334.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 784.17 -212.98 L 1963 338.91" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -584.33 402.95 L -584.33 481.63" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -584.33 553.53 L -584.33 592.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 38.87 402.95 L 38.87 439.31" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 677.83 -205.89 L -358.07 335.63" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 692.93 -205.89 L -63.93 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 700.57 -205.89 L 80.39 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 688.28 -211.35 L -361.17 337.26" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 695.53 -207.74 L -63.93 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 701.09 -206.34 L 80.39 331.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -418.07 402.95 L -418.07 481.63" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -418.07 576.93 L -418.07 618.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="-418.07" y="601.85" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M -418.07 678.37 L -418.07 741.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -418.07 801.37 L -418.07 845.06" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M -358.07 529.3 L -290.74 618.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="-343.4" y="552.9" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M -358.08 529.29 L -290.74 618.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="-343.41" y="552.89" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M -268.07 678.37 L -268.07 735.42" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -268.07 807.32 L -268.07 850.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -268.07 910.37 L -268.07 961.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -35,8 +35,8 @@
 <path d="M -114.6 402.95 L -114.6 481.63" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -114.6 678.37 L -114.6 741.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M -114.6 801.37 L -114.6 837.32" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M -54.6 529.3 L 13.12 618.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="-18.87" y="580.5" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M -54.61 529.29 L 13.12 618.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="-18.88" y="580.48" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 35.93 678.37 L 35.93 735.42" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 202.87 402.95 L 205.01 444.17" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 206.88 516.07 L 206.88 557.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -66,10 +66,10 @@
 <path d="M 1840.5 642.88 L 1840.5 672.88" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1810.5" y="662.06" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1840.5 744.78 L 1840.5 783.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1718 480.6 L 1745.26 480.6 L 1745.26 769.26 L 1780.5 785.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1718 480.6 L 1745.26 480.6 L 1745.26 769.26 L 1791.43 790.73" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1745.24" y="500.21" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1994.25 402.95 L 1878.6 547.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1900.5 595.23 L 1921.26 595.23 L 1921.26 765.26 L 1890.67 783.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1994.25 402.95 L 1863.8 566.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1900.5 595.23 L 1921.26 595.23 L 1921.26 765.26 L 1884.43 787.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1916.04" y="629.43" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <g transform="translate(675.22 -265.89) scale(1.02 1.03) translate(-1 -1)" style="stroke-width:0.97"><g fill="#FFFFFF" stroke="#000000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="butt">
     <rect x="1.0" y="1.0" width="118" height="58" rx="30.0" ry="30.0" />

--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_AwaitingV22Connection.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_AwaitingV22Connection.svg
@@ -1,10 +1,10 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="3249.94" height="1901.2" viewBox="4 -421.74 3249.94 1901.2" font-family="Helvetica, Arial, sans-serif">
 <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 1 L 9 5 L 0 9 z" fill="#000000"/></marker></defs>
 <rect x="4" y="-421.74" width="3249.94" height="1901.2" fill="#FFFFFF"/>
-<path d="M 1461.63 -341.74 L 144 334.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1467.74 -341.74 L 294 330.68" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1473.84 -341.74 L 439.43 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1479.95 -341.74 L 582.11 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1472.81 -347.48 L 144 334.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1475.17 -346 L 294 330.68" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1478.07 -344.48 L 439.43 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1481.85 -343.16 L 582.11 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1491.88 -341.74 L 860.82 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1500.3 -341.74 L 1057.6 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1506.41 -341.74 L 1200.28 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -16,8 +16,8 @@
 <path d="M 384 401 L 384 465.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 384 537.11 L 384 584.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 534 401 L 534 453.51" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 593.99 548.81 L 593.99 695.6 L 575.4 709.06" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="593.99" y="609.27" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 593.99 501.17 L 593.99 695.6 L 573.1 710.73" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="579.99" y="602.58" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 534 548.81 L 534 548.81" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="534" y="567.36" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 534 667.55 L 534 709.06" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -33,36 +33,36 @@
 <path d="M 1493.88 669.34 L 1493.88 723.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1493.88" y="700.89" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 1493.88 795.88 L 1493.88 834.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1553.86 669.34 L 1553.86 816.25 L 1531.52 834.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1564.18" y="700.08" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 1703.88 508.55 L 1786.16 828.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1731.73" y="621.05" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1553.86 621.7 L 1553.86 816.25 L 1530.39 834.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1539.86" y="723.18" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1703.86 508.5 L 1786.16 828.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1731.72" y="621.01" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 1643.88 401 L 1643.88 460.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1645.23 556.14 L 1646.59 603.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1645.91" y="584.2" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1645.2 555.09 L 1646.59 603.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1645.88" y="583.14" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1647.44 663.85 L 1647.44 723.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1647.44 783.98 L 1647.44 828.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1647.44 888.49 L 1647.44 918.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1536.1 -341.74 L 1893.77 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1548.08 -341.74 L 2173.6 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1561.78 -341.74 L 2493.86 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1567.89 -341.74 L 2636.55 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1574 -341.74 L 2783.81 331.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1580.1 -341.99 L 2948.88 336.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1580.1 -345.01 L 3113.94 338.32" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1559.39 -343.47 L 2493.86 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1562.89 -344.88 L 2636.55 329.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1565.71 -346.36 L 2783.81 331.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1568.01 -347.98 L 2948.88 336.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1569.94 -349.54 L 3113.94 338.32" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3173.94 401 L 3173.94 437.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1912.94 401 L 1912.94 427.78" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1852.94 475.46 L 1828.22 523.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1814.09" y="489.38" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1852.95 475.44 L 1828.22 523.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1814.1" y="489.36" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 1813.62 583.08 L 1814.6 613.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1887.92 720.74 L 1887.92 720.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1848.19" y="799.93" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 1887.27 768.39 L 1885.39 904.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1887.07" y="786.94" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 1941.59 768.39 L 1941.59 768.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1941.59" y="772.59" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 2016.29 863.69 L 2032.02 899.36" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2011.35" y="891.38" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1887.27 767.87 L 1885.39 904.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1887.08" y="786.42" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1916.25 745.89 L 1966.93 790.89" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1950.89" y="762.12" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2010.83 851.33 L 2032.02 899.36" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1992.03" y="887.23" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 1985.26 931.15 L 1942.04 932.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1884.98 964.16 L 1884.98 1020.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2055.26 816.04 L 2114.99 816.04 L 2114.99 999.76 L 1944.98 1050.06" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -76,8 +76,8 @@
 <path d="M 2207.12 659.87 L 2207.12 713.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2207.12 773.62 L 2207.12 827.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2207.12 887.37 L 2207.12 924.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2267.12 552.22 L 2338.87 599.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2303.95" y="616.89" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2239.8 534.08 L 2338.87 599.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2276.63" y="598.75" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2384.05 659.87 L 2384.05 713.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2384.05 785.52 L 2384.05 827.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2384.05 887.37 L 2384.05 924.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -97,8 +97,8 @@
 <path d="M 3009.93 536.12 L 3011.49 580.48" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3011.41 652.37 L 3010 690.25" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3008.88 402.49 L 3008.88 476.12" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1484.85 -341.74 L 1484.85 -341.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 651.39 403.66 L 591.38 453.51" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1485.44 -342.24 L 1485.44 -342.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 651.39 403.66 L 563.33 476.8" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <g transform="translate(1460.1 -401.74) scale(1.02 1.03) translate(-1 -1)" style="stroke-width:0.97"><g fill="#FFFFFF" stroke="#000000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="butt">
     <rect x="1.0" y="1.0" width="118" height="58" rx="30.0" ry="30.0" />
   </g>

--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_Connected.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_Connected.svg
@@ -1,18 +1,18 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="5557.11" height="2591.33" viewBox="248 -340.48 5557.11 2591.33" font-family="Helvetica, Arial, sans-serif">
 <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 1 L 9 5 L 0 9 z" fill="#000000"/></marker></defs>
 <rect x="248" y="-340.48" width="5557.11" height="2591.33" fill="#FFFFFF"/>
-<path d="M 2161.96 -261.74 L 388 588.25" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2173.43 -267.23 L 388 588.25" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 328 652.95 L 328 697" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 328 757 L 328 794.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 328 865.95 L 328 929" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 328 989 L 328 1038" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1385.6 652.95 L 1385.6 721.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2281.96 -264.98 L 4297.11 591.5" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2164.54 -260.48 L 545 585.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2174.46 -260.48 L 841.92 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2179.42 -260.48 L 985.98 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2184.38 -260.48 L 1130.04 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2189.15 -260.48 L 1268.53 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2272.63 -268.95 L 4297.11 591.5" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2175.01 -265.95 L 545 585.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2179.31 -263.55 L 841.92 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2182.11 -262.38 L 985.98 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2185.49 -261.37 L 1130.04 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2189.46 -260.78 L 1268.53 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2194.32 -260.48 L 1418.73 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2200.23 -260.48 L 1590.63 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2204.95 -260.48 L 1727.69 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -25,20 +25,20 @@
 <path d="M 2239.43 -260.48 L 2729.4 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2244.23 -260.48 L 2868.66 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2248.83 -260.48 L 3002.41 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2253.79 -260.48 L 3146.47 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2258.5 -260.48 L 3283.23 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2263.45 -260.48 L 3427.28 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2268.53 -260.48 L 3574.71 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2273.6 -260.48 L 3724.02 582.14" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2281.96 -262.96 L 4139.94 589.47" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2253.57 -260.69 L 3146.47 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2257.69 -261.15 L 3283.23 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2261.12 -262.17 L 3427.28 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2264.15 -263.3 L 3574.71 581.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2266.57 -264.57 L 3724.02 582.14" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2271.28 -267.86 L 4139.94 589.47" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 485 652.95 L 485 688.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 483.91 765.61 L 483.91 801.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 671.4 790.35 L 784.24 968.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="690.65" y="825.02" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 658.95 770.62 L 784.24 968.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="678.19" y="805.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 635 790.35 L 635 861.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="635" y="816.7" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 704.98 953.3 L 736.7 968.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="727.05" y="952.8" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 678.72 940.31 L 736.7 968.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="713.92" y="946.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 635 976.32 L 635 1027.31" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="635" y="994.88" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 635 1087.31 L 635 1138.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -47,9 +47,9 @@
 <path d="M 635 1475.13 L 635 1514.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="635" y="1493.66" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 635 1574.22 L 635 1613.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 695 1427.48 L 729.43 1427.48 L 729.43 1590.81 L 688.97 1613.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 695 1427.48 L 729.43 1427.48 L 729.43 1590.81 L 680.64 1617.93" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="716.02" y="1431.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 793.33 1046.21 L 793.33 1587.43 L 695 1622.13" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 793.33 1046.21 L 793.33 1587.43 L 688.12 1624.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 785 652.95 L 785 682.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 785 754.85 L 785 771.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 935 652.95 L 935 690.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -58,29 +58,29 @@
 <path d="M 935 930.02 L 935 960.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 935 1128.04 L 935 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 935 1031.92 L 935 1068.04" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 969.67 805.42 L 999.36 854.79 L 999.36 1136.34 L 942.31 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="987.78" y="839.73" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1045.73 805.42 L 1012.09 854.79 L 1012.09 1136.34 L 943.75 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1023.39" y="842.4" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 958.18 786.33 L 999.36 854.79 L 999.36 1136.34 L 942.31 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="976.3" y="820.64" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1059.84 784.7 L 1012.09 854.79 L 1012.09 1136.34 L 943.75 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1037.51" y="821.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 1085 652.95 L 1085 690.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1085 805.42 L 1085 870.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1055" y="841.91" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1085 930.02 L 1085 966.14" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1085 1038.04 L 1085 1068.04" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1085 1128.04 L 1085 1148.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1050.03 1243.84 L 957.01 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1028.32" y="1277.63" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1062.91 1226.29 L 957.01 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1041.2" y="1260.08" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1085 1243.84 L 1085 1286.92" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1085" y="1269.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1031.22 1346.92 L 988.78 1370.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1031.22 1346.92 L 980.55 1375.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1229.2 652.95 L 1229.2 870.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1229.2 930.02 L 1229.2 972.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1229.2 1032.09 L 1229.2 1068.04" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1229.2 1128.04 L 1229.2 1148.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1229.2 1243.84 L 1229.2 1286.92" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1229.2" y="1262.38" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1283.67 1243.84 L 1332.91 1286.92" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1299.07" y="1280.12" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1257.75 1221.16 L 1333.39 1287.34" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1297.39" y="1260.04" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1564.59 781.08 L 1564.59 794.08 L 1289.2 881.07" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1707.3 781.08 L 1707.3 791.08 L 1289.2 886.35" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1857.3 781.08 L 1857.3 788.08 L 1289.2 889.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -97,29 +97,29 @@
 <path d="M 2434.88 760.42 L 2409.67 803.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2388.53 875.17 L 2388.53 918.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2388.53 978.02 L 2388.53 1004.42" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2389.35 1064.42 L 2390.17 1094.42" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2341.97 1189.73 L 2307.09 1223.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2332.96" y="1204.46" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 2389.35 1064.42 L 2390.19 1095.44" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2364.35 1168.19 L 2307.09 1223.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2345.43" y="1210.03" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2249.01 1335.14 L 2249.01 1365.14" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2402.3 1189.73 L 2413.71 1239.94" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2408.87" y="1222.83" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2400.64 1182.44 L 2413.71 1239.94" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2407.21" y="1215.54" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2422.76 1299.94 L 2425.97 1342.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2371.15 1343.13 L 2309.01 1310.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2384.27 1349.99 L 2309.01 1310.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2593.89 652.95 L 2593.89 700.42" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2593.89 760.42 L 2593.89 815.17" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2593.89 875.17 L 2593.89 910.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2593.89 970.98 L 2593.89 1006.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2577.19 1102.1 L 2556.48 1161.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2564.17" y="1143.48" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 2621.84 1102.1 L 2656.53 1161.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2642.32" y="1141.2" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 2580.82 1091.73 L 2556.48 1161.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2567.8" y="1133.1" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2612.96 1086.95 L 2656.53 1161.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2633.43" y="1126.05" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2700.75 652.95 L 2635.26 700.42" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2895.34 652.95 L 2895.34 693.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2895.34 753.38 L 2895.34 789.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2896.98 884.32 L 2898.21 919.94" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2897.48" y="902.87" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 2835.35 884.32 L 2835.35 998.58 L 2871.11 1024.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2835.35" y="946.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2896.94 883.05 L 2898.21 919.94" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2897.43" y="901.6" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 2835.35 836.68 L 2835.35 998.58 L 2871.11 1024.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2835.35" y="899.04" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2899.25 979.94 L 2899.25 1024.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3034.6 652.95 L 3034.6 693.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3034.6 753.38 L 3034.6 794.31" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -135,13 +135,13 @@
 <path d="M 3328.39 753.63 L 3330.27 794.31" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3433.69 753.63 L 3374.96 794.31" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3331.66 854.31 L 3331.66 905.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3332.95 1019.27 L 3333.92 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3333.43" y="1044.84" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3332.93 1018.33 L 3333.92 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3333.41" y="1043.9" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3334.6 1122.01 L 3334.6 1152.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3403.67 1019.27 L 3457.81 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3422.07" y="1055.83" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3445.5 1260.06 L 3400.37 1302.81" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3413.31" y="1275.47" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3368.82 991.76 L 3457.81 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3418.67" y="1035.31" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3468.45 1238.33 L 3400.17 1303" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3425.58" y="1283.13" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3495.81 1260.06 L 3495.81 1302.81" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3495.81" y="1282.83" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3495.81 1122.01 L 3495.81 1164.76" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -151,34 +151,34 @@
 <path d="M 3630.51 879.61 L 3630.51 909.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3630.51 1071.51 L 3630.51 1152.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3630.51 969.61 L 3630.51 999.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3578.02 778.25 L 3551.4 802.41 L 3551.4 982.41 L 3577 999.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3542.21" y="814.96" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3602.51 756.02 L 3551.4 802.41 L 3551.4 982.41 L 3577 999.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3566.7" y="792.72" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3784.02 652.95 L 3784.02 700.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3784.02 760.6 L 3784.02 815.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3784.02 875.53 L 3784.02 909.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3784.02 1004.92 L 3784.02 1044.36" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3784.02" y="1023.45" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 3844.02 997.59 L 3939.87 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3882.69" y="1027.79" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3816.52 979.11 L 3939.87 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3855.19" y="1009.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3784.02 1139.67 L 3784.02 1182.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3784.02" y="1158.22" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3784.02 1242.41 L 3784.02 1285.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3823.87 1139.67 L 3857.54 1179.93 L 3857.54 1275.93 L 3840.24 1285.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3849.32" y="1174.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3807.97 1120.65 L 3857.54 1179.93 L 3857.54 1275.93 L 3840.24 1285.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3833.41" y="1155.28" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3784.02 1345.16 L 3784.02 1375.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3784.02 1435.16 L 3784.02 1474.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3790.61 1626.24 L 3790.61 1626.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3790.36 1662.19 L 3790.19 1687.94" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3789.93 1765.17 L 3789.93 1799.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3984.5 1122.01 L 3984.5 1164.76" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3961.09 1260.06 L 3948.76 1285.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3967.49" y="1282.98" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4022.27 1260.06 L 4042.15 1285.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4043.18" y="1268.12" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3967.66 1246.69 L 3948.76 1285.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3956.09" y="1274.44" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4007.68 1241.66 L 4042.15 1285.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4029.72" y="1273.67" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4199.94 652.95 L 4199.94 696.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4199.94 756.56 L 4199.94 793.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4139.94 975.64 L 4024.57 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4098.38" y="1010.96" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4169.05 953.84 L 4024.57 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4127.49" y="989.16" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4199.94 853.2 L 4199.94 883.06" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4199.94 978.37 L 4199.94 1062.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4199.94" y="996.93" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
@@ -193,14 +193,14 @@
 <path d="M 4357.99 1025.58 L 4359.17 1065.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4360.05 1125.84 L 4360.05 1175.69" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4360.05 1235.69 L 4360.05 1255.2 L 4281.6 1255.2 L 4281.6 1158.99 L 4012.8 1158.99 L 4012.8 1158.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4417.11 894.98 L 4422.4 896.8 L 4475.52 896.8 L 4475.52 806.56 L 4576.64 806.56 L 4576.64 806.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4462.12" y="905.13" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4516.65 922.03 L 4516.65 937.12 L 4317.44 937.12 L 4246.4 995.36 L 4044.5 1069.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4479.77" y="985.14" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4401.03 889.46 L 4422.4 896.8 L 4475.52 896.8 L 4475.52 806.56 L 4576.64 806.56 L 4576.64 806.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4446.04" y="899.6" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4516.65 874.39 L 4516.65 937.12 L 4317.44 937.12 L 4246.4 995.36 L 4044.5 1069.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4479.77" y="937.5" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4576.64 922.03 L 4576.64 978.8" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4546.64" y="954.58" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4417.1 783.17 L 4417.1 795.68 L 4723.69 795.68 L 4723.69 844.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4417.1" y="835.55" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4417.1 735.53 L 4417.1 795.68 L 4723.69 795.68 L 4723.69 844.37" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4431.1" y="769.8" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4723.04 904.37 L 4721.41 978.8" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4720.75 1038.8 L 4720.75 1073.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4576.64 1038.8 L 4576.64 1119.64" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -215,62 +215,62 @@
 <path d="M 4577.62 1829.2 L 4578.6 1859.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4579.58 1919.2 L 4579.58 1938.08 L 4443.55 1938.08 L 4443.55 1829.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4443.55 1769.2 L 4443.55 1621.28 L 4555.52 1621.28 L 4555.52 1621.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4636.64 1690 L 4636.64 1690" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4653.73" y="1695.91" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4629.92 1689.33 L 4629.92 1689.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4647.02" y="1695.24" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4786.36 1800.29 L 4786.36 1841.54" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4786.36" y="1818.85" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4786.36 1936.85 L 4786.36 1966.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4786.36" y="1955.37" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4786.36 2038.75 L 4786.36 2074.8" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4786.36 2134.8 L 4786.36 2170.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4726.36 1889.2 L 4699.16 1889.2 L 4699.16 2151.52 L 4733.33 2170.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4726.36 1889.2 L 4699.16 1889.2 L 4699.16 2151.52 L 4741.13 2175.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4712.77" y="1893.4" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4841.02 1800.29 L 4908.58 1859.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4858.63" y="1825.94" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4814.96 1777.57 L 4908.58 1859.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4852.57" y="1833.14" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4943 1919.2 L 4943 1966.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4943 2038.75 L 4943 2074.8" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4943 2134.8 L 4943 2170.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4636.64 1316.18 L 4713.4 1318.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4651.31" y="1320.74" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4634.85 1316.14 L 4715.18 1318.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4649.52" y="1320.69" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4975.89 1367.17 L 4975.89 1446.24 L 4833.4 1446.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4975.89" y="1385.7" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4773.4 1476.24 L 4773.4 1514.43" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4943 1889.2 L 4943 1889.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4943" y="1893.4" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4833.4 1562.1 L 5017.24 1855.2 L 5017.24 2145.12 L 4982.96 2170.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4848.06" y="1589.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4833.39 1562.09 L 5017.24 1855.2 L 5017.24 2145.12 L 4981.12 2172.23" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4848.05" y="1589.66" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5035.89 1319.52 L 5118.39 1319.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5065.65" y="1323.72" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5178.39 1367.17 L 5178.39 1405.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5148.39" y="1390.56" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5178.39 1504.67 L 5178.39 1537.83" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5184.93 1609.73 L 5228.31 1848.29 L 5228.31 2050.53 L 5003 2093.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5238.39 1319.54 L 5323.04 1429.81" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5255.72" y="1346.31" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5238.38 1319.52 L 5323.04 1429.81" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5255.71" y="1346.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5346.07 1489.81 L 5346.07 1526.13" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5286.08 1621.43 L 5286.08 1664.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5284.97" y="1658.74" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5286.08 1573.79 L 5286.08 1664.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5272.08" y="1623.12" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5303.43 1724.05 L 5385.68 1866.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5403.03 1926.29 L 5403.03 1956.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5403.03 2028.18 L 5403.03 2080.69" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5406.07 1573.78 L 5499.79 1573.78 L 5499.79 1573.78" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5420.71" y="1577.98" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5559.78 1646.26 L 5559.78 1385.57 L 5228.95 1385.57 L 5214.46 1405.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5557.14" y="1628.58" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5559.78 1693.9 L 5559.78 1385.57 L 5228.95 1385.57 L 5214.46 1405.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5573.78" y="1543.93" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5499.79 1741.57 L 5499.79 1771.57" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5499.79" y="1760.77" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5469.14 1831.57 L 5433.68 1866.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4636.64 1175.52 L 5626.71 1311.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5035.22" y="1276.99" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4627.8 1174.31 L 5626.71 1311.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5026.39" y="1275.78" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5686.71 1349.52 L 5686.71 1387.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5686.71 1483.3 L 5686.71 1534.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5686.71" y="1513.17" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5686.71 1594.65 L 5686.71 1646.26" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5686.71 1718.16 L 5686.71 1779.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5686.71 1839.65 L 5686.71 1901.13" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5746.71 1435.66 L 5785.11 1486.05 L 5785.11 1880.65 L 5745.18 1901.13" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5777.04" y="1456.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 2167.45 -260.48 L 638.04 581.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 5746.7 1435.65 L 5785.11 1486.05 L 5785.11 1880.65 L 5733.99 1906.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5777.04" y="1456.56" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2176.09 -265.24 L 638.04 581.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 635 732.71 L 635 732.71" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4833.4 1319.52 L 4915.89 1319.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4865.83" y="1323.72" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>

--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_Disconnected.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_Disconnected.svg
@@ -1,20 +1,20 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="2221" height="1699.33" viewBox="140 -183.33 2221 1699.33" font-family="Helvetica, Arial, sans-serif">
 <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 1 L 9 5 L 0 9 z" fill="#000000"/></marker></defs>
 <rect x="140" y="-183.33" width="2221" height="1699.33" fill="#FFFFFF"/>
-<path d="M 1282 -108.66 L 280 303.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1290.8 -112.27 L 280 303.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 220 363.95 L 220 411" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 220 471 L 220 518.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1282 -104.58 L 439 299.26" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1293.46 -110.07 L 439 299.26" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 379 363.95 L 379 405.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 379 476.95 L 379 518.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 684.88 363.95 L 684.88 422.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1289.13 -103.33 L 589 293.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1299.27 -103.33 L 736.09 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1296.85 -107.7 L 589 293.95" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1302.02 -105.26 L 736.09 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 529 363.95 L 529 411" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 529 471 L 529 518.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 529 578.05 L 529 625.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 529 685.1 L 529 743.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1310.07 -103.33 L 889.26 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1310.3 -103.54 L 889.26 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 851 363.95 L 851 411" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 851 471 L 851 512.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 851 584 L 851 625.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -35,27 +35,27 @@
 <path d="M 1361.51 -103.33 L 1618.62 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1371.26 -103.33 L 1756.93 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1792 363.95 L 1792 411" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1849.06 557.14 L 1886.98 927.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1855.4" y="623.2" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1791.24 471 L 1790.27 509.35" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1849.04 557.01 L 1886.98 927.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1855.39" y="623.07" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1791.24 471 L 1790.24 510.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1789.06 692.38 L 1789.06 692.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1789.06" y="696.58" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1789.06 722.38 L 1789.06 774.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1813.76 846.05 L 1869.45 927.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1381.73 -103.33 L 1905.39 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1379.97 -104.66 L 1905.39 292.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1953 363.95 L 1953 411" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1953 602.5 L 1953 662.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1953 471 L 1953 530.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1392.92 -103.33 L 2065 292.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1386.27 -107.24 L 2065 292.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2125 363.95 L 2125 411" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2125 471 L 2125 518.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2065 566.55 L 2007.12 566.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="2050.34" y="570.75" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1402 -103.85 L 2221 298.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1390.08 -109.7 L 2221 298.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2281 363.95 L 2281 411" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2281 471 L 2281 518.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2221 529.39 L 2159 491 L 2053 491 L 2003.2 530.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2173.19" y="503.99" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2247.29 545.67 L 2159 491 L 2053 491 L 1994.14 537.81" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2199.47" y="520.26" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2125 614.2 L 2125 662.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="2095" y="642.5" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2281 614.2 L 2281 662.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>

--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_Subroutines.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_Subroutines.svg
@@ -6,121 +6,121 @@
 <path d="M 231.34 555.05 L 231.34 585.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 231.34 645.05 L 231.34 671.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 407.04 336.95 L 408.11 386" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 404.67 616.24 L 402.59 656.68" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 404.67 616.24 L 402.58 656.93" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 566.22 336.95 L 568.2 391.97" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 569.27 451.97 L 569.27 481.97" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 569.27 577.27 L 569.27 648.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="539.27" y="616.92" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 613.05 577.27 L 682.36 652.71" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="633.2" y="647.75" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 594.58 557.17 L 682.36 652.71" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="614.73" y="627.65" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 569.27 719.99 L 569.27 804.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 679.35 724.61 L 599.34 804.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 571.76 864.45 L 575.73 912.36" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 571.76 864.45 L 575.76 912.76" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 937.16 336.95 L 939.35 404.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 943.13 464.45 L 947.54 511.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 948.05 606.9 L 944.27 652.71" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="946.87" y="625.45" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 1000.33 724.27 L 1084.95 757.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1034.46" y="742.07" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 943.13 464.45 L 947.85 514.89" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 948.3 603.96 L 944.02 655.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="947.11" y="622.52" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 980.28 716.28 L 1084.95 757.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1014.42" y="734.08" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1141.21 815.49 L 1147.32 917.73" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1150.59 977.73 L 1194.53 1870.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 932.13 748.02 L 922.43 804.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="929.34" y="768.47" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 908.32 899.75 L 899.29 972.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="906.55" y="918.29" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 895.11 1067.91 L 899.07 1177.57" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="896.39" y="1107.67" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 893.53 1237.57 L 876.75 1313.51" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 868.03 1408.82 L 870.76 1480.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="868.58" y="1427.37" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1150.59 977.73 L 1194.55 1871.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 933.12 742.29 L 921.44 810.17" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="930.32" y="762.74" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 908.85 895.48 L 898.76 976.88" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="907.08" y="914.02" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 895.06 1066.59 L 899.07 1177.57" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="896.34" y="1106.34" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 893.53 1237.57 L 875.18 1320.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 867.98 1407.43 L 870.76 1480.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="868.52" y="1425.98" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 867.57 1552.63 L 856.58 1639.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 861.62 1711.49 L 882.56 1790.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 950.55 1839.67 L 1147.52 1904.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 950.55 1839.67 L 1150.19 1904.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 891.99 559.25 L 811.66 559.25 L 724.16 1625.74 L 797.92 1654.46" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="877.31" y="563.45" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 940.35 1067.91 L 1088.22 1217.92 L 926.23 1322.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="972.67" y="1104.9" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 901.95 1408.82 L 990.99 1527.61 L 885.8 1639.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="924.13" y="1442.61" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 919.73 1046.99 L 1088.22 1217.92 L 899.34 1339.8" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="952.04" y="1083.97" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 888.62 1391.04 L 990.99 1527.61 L 885.8 1639.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="910.8" y="1424.83" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 1574.71 318.31 L 1580.02 384.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1577.21 444.86 L 1564.09 520.63" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1561.45 597.86 L 1566.27 643.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1561.93 703.86 L 1550.47 749.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1598.6 750.99 L 1697.96 673.95 L 1604.72 597.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1619.84" y="739.74" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1530.08 845.17 L 1521.85 891.17" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1495.14" y="874.29" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1561.93 703.86 L 1548.51 757.73" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1568.96 773.97 L 1697.96 673.95 L 1604.72 597.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1642.04" y="739.23" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1531.14 839.24 L 1521.69 892.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1496.2" y="868.36" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1818.92 318.31 L 1818.92 367.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1878.92 442.63 L 1968.84 484.26" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1915.08" y="463.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 1817.54 462.51 L 1815.97 516.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1786.74" y="493.86" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1867.26 612.16 L 1920.8 660.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1884.64" y="650.96" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1856.83 432.41 L 1968.84 484.26" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1892.99" y="453.34" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1817.57 461.44 L 1815.93 517.93" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1786.77" y="492.79" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1842.64 589.88 L 1920.8 660.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1858.73" y="649.09" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1954.97 720.59 L 1956.79 774.51" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1961.24 834.51 L 1971.33 922.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1799.29 612.16 L 1763.5 723.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1792.58" y="637.25" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1799.6 818.92 L 1927.56 937.57" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1821.88" y="840.26" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 1746.53 818.92 L 1743.81 896.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1715.15" y="861.7" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1802.76 937.86 L 1927.56 962.29" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2053.72 542.03 L 2098.12 595.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2114.35 690.88 L 2001.16 922.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2096.17" y="732.29" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 2143.05 690.88 L 2157.92 821.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2145.86" y="719.87" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 2115.28 881.87 L 2026.44 939.75" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1961.24 834.51 L 1971.39 923.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1802.39 602.48 L 1760.39 733.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1795.69" y="627.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1775.88 796.94 L 1935.61 945.03" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1846.23" y="885.45" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1746.57 817.63 L 1743.81 896.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1715.2" y="860.41" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1802.76 937.86 L 1928.49 962.47" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2053.72 542.03 L 2113.82 614.5" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2120.87 677.56 L 1998.62 927.73" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2102.68" y="718.97" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 2142.6 686.94 L 2157.92 821.87" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2145.41" y="715.93" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2115.28 881.87 L 2018.38 945.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2429.04 318.31 L 2429.04 375.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2560.74 318.31 L 2474.1 375.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2428.08 435.99 L 2426.23 493.67" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2484.7 568.65 L 2594.34 618.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2531.71" y="594.26" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 2426.99 588.97 L 2428.86 627.76" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2397.89" y="612.56" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 2566.29 314.62 L 2474.1 375.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2428.08 435.99 L 2426.19 494.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2462.84 558.69 L 2594.34 618.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2509.84" y="584.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2426.91 587.22 L 2428.86 627.76" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2397.81" y="610.81" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2428.62 699.66 L 2426.34 741.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2424.7 801.27 L 2424.7 842.89" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2889.29 457.73 L 2883.49 511.32" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2887.74" y="476.29" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 2897.62 313.55 L 2896.02 362.43" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2875.3 571.32 L 2864.69 635.83" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2954.46 430.42 L 3068.55 469.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2983.55" y="444.48" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3068.55 532.64 L 2906 649.68" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3028.32" y="565.81" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3122.4 537.09 L 3115.15 593.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3088.37" y="570.53" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 3054.22 637.1 L 2906 673.23" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3369.03 313.55 L 3370.78 370.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3422.83 465.41 L 3553.03 588.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3458.3" y="503.03" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3576.69 648.08 L 3529.41 821.43" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3349.44 465.41 L 3320.32 526.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3337.78" y="493.98" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 3283.47 621.57 L 3260.49 699.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3274.15" y="657.41" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 3307.75 759.55 L 3466.48 844.44" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3355.32 621.57 L 3396.53 655.54" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3377.36" y="642.58" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3446.36 715.54 L 3493.78 821.43" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3833.3 313.55 L 3831.81 357.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2889.7 453.95 L 2883.49 511.32" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2888.15" y="472.51" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 2897.62 313.55 L 2895.98 363.63" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2875.3 571.32 L 2864.56 636.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2936.51 424.33 L 3086.5 475.18" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2965.6" y="438.39" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3097.08 512.1 L 2896.57 656.47" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3056.85" y="545.27" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3122.97 532.66 L 3115.15 593.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3088.95" y="566.09" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3061.18 635.41 L 2904.43 673.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3369.03 313.55 L 3370.81 371.25" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3399.69 443.61 L 3553.03 588.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3435.16" y="481.23" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3576.69 648.08 L 3528.88 823.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3355.73 452.29 L 3314.04 539.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3344.06" y="480.86" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3286.14 612.53 L 3260.49 699.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3276.81" y="648.37" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3307.75 759.55 L 3472.54 847.67" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3326.96 598.19 L 3396.53 655.54" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3352.84" y="641.87" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3446.36 715.54 L 3495.77 825.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3833.3 313.55 L 3831.77 358.59" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3830.19 452.64 L 3830.19 518.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3830.19" y="471.2" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 3827.17 578.98 L 3819.49 655.54" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3890.19 408.44 L 3992.12 414.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3904.85" y="413.48" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4012.7 465.41 L 3855.42 655.54" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3986.62" y="501.14" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4060.69 465.41 L 4082.73 588.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4065.86" y="498.42" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4028.12 637.14 L 3863.97 689.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3827.17 578.98 L 3819.44 656.03" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3886.13 408.2 L 3996.18 414.54" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3900.79" y="413.25" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4028.33 446.52 L 3845.89 667.07" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4002.25" y="482.25" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4059.62 459.46 L 4082.73 588.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4064.79" y="492.46" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4028.12 637.14 L 3861.42 690.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4314.52 313.55 L 4314.52 370.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4316.15 430.11 L 4318.07 465.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4316.15 430.11 L 4318.08 465.71" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4493.31 308.47 L 4493.31 365.03" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4494.94 425.03 L 4496.85 460.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 941.35 899.75 L 1149.11 1264.81 L 1120.91 1619.21 L 906.15 1664.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1025.68" y="1112.77" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4494.94 425.03 L 4496.87 460.64" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 932.91 884.92 L 1149.11 1264.81 L 1120.91 1619.21 L 901.47 1665.18" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1017.23" y="1097.94" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2594.34 674.2 L 2477.13 741.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <g transform="translate(162.66 265.05) scale(5.15 7.08) translate(-6.16 -6.64)" style="stroke-width:0.14"><g>
     <path style="fill:none;stroke:#000000;stroke-width:0.264583;stroke-opacity:1" d="M 9.2383895,6.6360261 V 16.785243 H 28.040465 l 0,-10.1492169 z" />

--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_TimerRecovery.srej-received.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_TimerRecovery.srej-received.svg
@@ -10,39 +10,39 @@
 <path d="M 5218.76 961.07 L 5218.76 1004.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5218.76" y="979.61" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5218.76 1064.6 L 5218.76 1102.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5158.76 913.41 L 5110.35 913.41 L 5110.35 1171.81 L 5158.76 1202.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 5158.76 913.41 L 5110.35 913.41 L 5110.35 1171.81 L 5185.33 1219.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5127.22" y="917.61" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5218.76 1162.61 L 5218.76 1192.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5218.76 1287.92 L 5218.76 1339.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5188.76" y="1317.88" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 5278.76 1265.33 L 5871.15 1512.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5309.47" y="1332.38" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5278.76 659.71 L 5423.85 744.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5317.7" y="686.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5258.08 1256.69 L 5878.14 1515.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5288.8" y="1323.75" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5253.31 644.82 L 5423.85 744.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5292.25" y="671.8" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5475.15 804.58 L 5475.15 838.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5475.15 898.61 L 5475.15 928.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5257.08 822.23 L 5451.02 1063.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5280.87" y="856.01" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5242.14 803.66 L 5451.02 1063.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5265.93" y="837.44" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5475.15 1023.91 L 5475.15 1063.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5475.15" y="1042.44" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5475.15 1123.41 L 5475.15 1153.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5421.87 1248.72 L 5421.09 1249.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5387.81" y="1243.13" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5516.25 1248.72 L 5516.85 1249.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5527.15" y="1244.12" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 5535.15 997.18 L 5751.15 1072.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5566.92" y="1012.46" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5446.92 1226.31 L 5420.69 1249.77" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5443.14" y="1252.67" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5499.54 1229.34 L 5516.85 1249.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5518.8" y="1234.43" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5516.84 990.8 L 5769.45 1078.88" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5548.61" y="1006.08" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5811.15 1141.07 L 5811.15 1198.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5781.15" y="1174.06" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5811.15 1258.61 L 5811.15 1288.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5811.15 1348.61 L 5811.15 1384.96" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5751.15 1093.41 L 5716.75 1093.41 L 5716.75 1376.61 L 5751.15 1397.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 5751.15 1093.41 L 5716.75 1093.41 L 5716.75 1376.61 L 5776.8 1412.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5716.71" y="1118.01" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5766.53 1480.27 L 5738.44 1510.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5706.53" y="1504.65" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5785.56 1459.94 L 5738.44 1510.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5725.56" y="1484.33" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5710.35 1570.27 L 5710.35 1607.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5868.11 1480.27 L 5893.67 1501.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5889.87" y="1484.42" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5840.37 1457.06 L 5893.67 1501.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5855.8" y="1513.28" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5941.55 1651.01 L 5941.55 1651.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5941.55 1686.96 L 5941.55 1728.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5941.55 1788.53 L 5941.55 1920.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>

--- a/spec-sdl/v2.2-errata/data-link/svg/DataLink_TimerRecovery.svg
+++ b/spec-sdl/v2.2-errata/data-link/svg/DataLink_TimerRecovery.svg
@@ -1,12 +1,12 @@
 <svg xmlns="http://www.w3.org/2000/svg" width="5992.47" height="3145.55" viewBox="30.49 -316.32 5992.47 3145.55" font-family="Helvetica, Arial, sans-serif">
 <defs><marker id="arrow" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="8" markerHeight="8" orient="auto-start-reverse"><path d="M 0 1 L 9 5 L 0 9 z" fill="#000000"/></marker></defs>
 <rect x="30.49" y="-316.32" width="5992.47" height="3145.55" fill="#FFFFFF"/>
-<path d="M 1760.16 -243.83 L 170.49 352.17" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1760.16 -241.3 L 343.49 349.64" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1760.16 -238.96 L 1760.16 -238.96" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1771.16 -236.32 L 836.21 336.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1778.21 -236.32 L 977.76 336.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1785.17 -236.32 L 1114.42 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1767.79 -246.69 L 170.49 352.17" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1769.17 -245.05 L 343.49 349.64" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1770.74 -243.79 L 1770.74 -243.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1776.79 -239.77 L 836.21 336.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1780.7 -238.1 L 977.76 336.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1785.73 -236.8 L 1114.42 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1792.19 -236.32 L 1256.01 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1800.62 -236.32 L 1425.92 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1808.34 -236.32 L 1581.66 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -20,26 +20,26 @@
 <path d="M 283.49 525.62 L 283.49 558.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 461.86 413.28 L 461.86 448.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 646.14 879.73 L 646.14 879.73" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 503.98 543.7 L 503.98 543.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="531.82" y="579.4" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 486.61 524.05 L 486.61 524.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="514.45" y="559.74" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 461.86 543.7 L 461.86 593.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="461.86" y="562.27" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 521.86 662.35 L 521.86 662.35" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="553.63" y="677.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 503.63 656.03 L 503.63 656.03" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="535.4" y="671.25" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 461.86 689.21 L 461.86 733.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="461.86" y="715.53" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 461.86 793.41 L 461.86 834.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 461.86 906.88 L 461.86 955.11" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 461.86 1015.11 L 461.86 1058.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 521.86 1132.97 L 563.7 1151.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="537.14" y="1159.2" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 500.46 1123.55 L 573.66 1155.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="534.61" y="1142.79" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 461.86 1154.2 L 461.86 1200.25" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="431.86" y="1181.45" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 461.86 1260.25 L 461.86 1306.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 777.49 407.95 L 777.49 448.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 777.49 520.29 L 777.49 558.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 927.49 407.95 L 927.49 448.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1073.97 410.61 L 1075.53 448.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1073.97 410.61 L 1075.59 449.91" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 927.49 543.7 L 927.49 584.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="927.49" y="562.24" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1077.49 543.7 L 1077.49 584.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -51,14 +51,14 @@
 <path d="M 1077.49 841.67 L 1077.49 890.46" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1077.49 985.77 L 1077.49 1030.17" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="1077.49" y="1004.32" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1030.75 1090.17 L 974.23 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1030.75 1090.17 L 969.77 1129.31" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 927.49 841.67 L 927.49 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 987.49 534.52 L 994.35 538.92 L 994.35 1014.12 L 941.58 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="988.34" y="559.39" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1017.49 530.62 L 1001.71 539.72 L 1001.71 1023.72 L 944.27 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1008.9" y="557.32" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 1044.75 985.77 L 948.1 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="1024.95" y="1018.79" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 960.69 517.34 L 994.35 538.92 L 994.35 1014.12 L 941.58 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="985.07" y="520.54" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1042.72 516.08 L 1001.71 539.72 L 1001.71 1023.72 L 944.27 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1029.2" y="544.23" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 1056.31 968.95 L 948.1 1126.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="1036.51" y="1001.97" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 1222.49 410.61 L 1222.49 584.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1222.23 644.15 L 1221.87 685.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1221.61 745.72 L 1221.61 781.67" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -75,12 +75,12 @@
 <path d="M 1877.49 721.28 L 1877.49 762.03" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1835.41 -236.32 L 2127.62 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 1843.64 -236.32 L 2293.55 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1851.06 -236.32 L 2443.19 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1858.48 -236.32 L 2592.84 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1865.5 -236.32 L 2734.43 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1872.52 -236.32 L 2878.75 340.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1879.54 -236.32 L 3028.75 344.35" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -239.21 L 3178.75 347.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1850.93 -236.45 L 2443.19 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1857.15 -237.36 L 2592.84 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1861.73 -238.82 L 2734.43 338.72" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1865.09 -240.58 L 2878.75 340.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1867.73 -242.29 L 3028.75 344.35" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1869.75 -243.92 L 3178.75 347.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2145.89 410.61 L 2145.89 468.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2145.89 528.99 L 2145.89 563.46" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2145.89 623.46 L 2145.89 669.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -88,7 +88,7 @@
 <path d="M 2321.67 410.61 L 2321.67 468.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2480.21 410.61 L 2480.21 468.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2321.67 528.99 L 2321.67 558.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2430.64 528.99 L 2375.79 562.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2430.64 528.99 L 2364.17 569.22" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2321.67 630.89 L 2321.67 669.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2321.67 729.52 L 2321.67 768.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2321.67 828.15 L 2321.67 858.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -97,7 +97,7 @@
 <path d="M 2321.67 1053.36 L 2321.67 1083.36" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2321.67 1143.36 L 2321.67 1173.36" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2321.67 1268.67 L 2321.67 1303.12" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2261.67 905.81 L 2232.61 905.81 L 2232.61 1275.52 L 2275.28 1303.12" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2261.67 905.81 L 2232.61 905.81 L 2232.61 1275.52 L 2279.57 1305.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="2239.84" y="880.01" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2638.75 410.61 L 2638.75 467" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2638.75 527 L 2638.75 561.64" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -105,11 +105,11 @@
 <path d="M 2638.75 719.95 L 2638.75 752.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2638.75 812.66 L 2638.75 842.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2788.75 410.61 L 2788.75 469.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2787.93 529.99 L 2787.11 559.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2787.93 529.99 L 2787.08 561.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2785.81 655.3 L 2785.81 692.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="2755.81" y="678.18" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2785.81 752.66 L 2785.81 790.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2845.81 607.65 L 2867.2 607.65 L 2867.2 778.01 L 2843.93 790.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 2845.81 607.65 L 2867.2 607.65 L 2867.2 778.01 L 2832.98 795.67" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="2861.88" y="641.85" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2938.75 410.61 L 2938.75 469.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 2938.75 529.99 L 2938.75 566.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -118,29 +118,29 @@
 <path d="M 2938.75 850.02 L 2938.75 884.71" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3088.75 410.61 L 3088.75 469.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3238.75 410.61 L 3238.75 469.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3129.25 529.99 L 3178.75 566.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3129.25 529.99 L 3207.7 588.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3238.75 529.99 L 3238.75 563.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3178.75 612.3 L 3148.75 612.9" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3164.1" y="616.79" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3132.54 661.75 L 3161.62 693.39 L 3161.62 1005.83 L 3160.71 1041.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3161.51" y="697.46" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3180.22 612.27 L 3147.27 612.93" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3165.57" y="616.76" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3114.06 641.64 L 3161.62 693.39 L 3161.62 1005.83 L 3160.71 1041.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3143.03" y="677.36" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3159.94 1101.84 L 3159.94 1137.25" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3102.11 1232.56 L 3065.71 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3081.66" y="1253.34" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3130.49 1209.17 L 3065.71 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3107" y="1250.87" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3029.3 1322.56 L 3029.3 1352.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3159.94 1232.56 L 3159.94 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3159.94" y="1251.11" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3159.94 1322.56 L 3159.94 1344.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3099.94 1438.41 L 3068.51 1462.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3075.72" y="1443.51" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3129.38 1415.89 L 3066.91 1463.68" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3087.08" y="1452.44" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3159.94 1440.16 L 3159.94 1462.45" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3145.94" y="1455.5" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3238.75 658.75 L 3238.75 684.89" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3208.75" y="676.51" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3238.75 744.89 L 3238.75 774.89" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3243.87 834.89 L 3295.51 1137.25" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3243.65 1229.85 L 3199.99 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3223" y="1249.11" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3243.87 834.89 L 3296.48 1142.94" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3272.77 1208.03 L 3199.99 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3227.99" y="1228.29" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3303.65 1232.56 L 3303.65 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3303.65" y="1251.76" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3303.65 1322.56 L 3303.65 1344.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -148,39 +148,39 @@
 <text x="3273.65" y="1459.36" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3303.65 1530.16 L 3303.65 1560.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3303.65 1620.16 L 3303.65 1654.67" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3363.65 1435.57 L 3411.85 1470.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3386.06" y="1458.03" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3335.17 1415.12 L 3411.85 1470.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3365.34" y="1458.21" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3453.65 1530.16 L 3453.65 1564.67" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -242.46 L 3371.4 350.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1871.79 -245.79 L 3371.4 350.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3431.4 410.61 L 3431.4 459.89" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3431.4 555.2 L 3431.4 585.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3431.4" y="573.75" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3431.4 645.2 L 3431.4 675.2" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3431.4 735.2 L 3431.4 773.43" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3491.4 507.54 L 3507.68 507.54 L 3507.68 760.91 L 3485.51 775" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3491.4 507.54 L 3507.68 507.54 L 3507.68 760.91 L 3473.45 782.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3503.6" y="541.74" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3431.4 845.33 L 3431.4 875.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -244.74 L 3542.2 353.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -248.81 L 3976.21 363.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -252.36 L 4540 366.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1873.06 -247.3 L 3542.2 353.08" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1875.33 -250.22 L 3976.21 363.15" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1876.9 -253.12 L 4540 366.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3602.2 555.2 L 3602.2 604.47" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3572.2" y="584.06" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 3602.2 410.61 L 3602.2 459.89" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3602.2 664.47 L 3602.2 694.47" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3602.2 754.47 L 3602.2 804.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3662.2 554.26 L 3705.22 587.76" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3707.02" y="555.34" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 3632.5 531.13 L 3734.92 610.88" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3677.32" y="532.21" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3765.22 682.13 L 3765.22 787.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3765.22" y="738.77" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 3765.22 882.31 L 3765.22 929" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3765.22" y="909.88" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 3744.06 682.13 L 3634.43 929" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3733.47" y="710.18" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3820.45 882.31 L 3874.57 929" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="3861.1" y="921.59" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 3661.63 989 L 3724.7 1035.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3749.58 669.7 L 3634.43 929" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3738.98" y="697.76" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3793.98 859.47 L 3874.57 929" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="3834.63" y="898.75" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 3661.63 989 L 3725.11 1036" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3765.22 989 L 3765.22 1035.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3868.81 989 L 3805.74 1035.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3869.22 988.7 L 3805.74 1035.7" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3765.22 1095.7 L 3765.22 1135.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3765.22 1195.4 L 3765.22 1225.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 3765.22 1297.3 L 3765.22 1327.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -196,12 +196,12 @@
 <path d="M 4037.26 838.44 L 4038.11 862.92" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4039.15 922.92 L 4039.15 958.68" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4039.15 1018.68 L 4039.15 1041.13" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4085.89 699.94 L 4174.02 784.47" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4120.71" y="737.53" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4063.39 678.35 L 4196.52 806.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4098.2" y="715.95" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4223.69 879.78 L 4223.69 916.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4193.69" y="902.52" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4283.69 878.01 L 4334.47 916.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4309.25" y="897.1" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4254.26 855.5 L 4334.47 916.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4285.86" y="901.49" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4223.69 976.84 L 4223.69 1006.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4600 416.61 L 4600 466.75" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4600 526.75 L 4600 562.1" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -210,48 +210,48 @@
 <path d="M 4600 788.06 L 4600 838.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4600" y="817.51" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4600 898.61 L 4600 928.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4660 740.4 L 4685.78 740.4 L 4685.78 901.41 L 4654.61 928.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4660 740.4 L 4685.78 740.4 L 4685.78 901.41 L 4628.59 951.31" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4679.32" y="744.6" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4600 1023.91 L 4600 1060.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4600" y="1042.46" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4660 1021.84 L 4710.51 1060.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4676.79" y="1056.37" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4630.67 999.56 L 4710.51 1060.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4671.76" y="1034.97" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4750 1120.21 L 4750 1162.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4719.02 1257.86 L 4699.51 1287.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4670.56" y="1281.56" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4781.95 1257.86 L 4802.07 1287.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4803.64" y="1269.27" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4729.57 1241.63 L 4699.51 1287.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4726.28" y="1276.58" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4770.85 1241.3 L 4802.07 1287.86" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4774.83" y="1276.58" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4600 1120.21 L 4600 1352.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4600 1447.51 L 4600 1585.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4600" y="1466.08" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4660 1429.32 L 4698.16 1448.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4672.91" y="1455.45" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4637.08 1418.07 L 4698.16 1448.05" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4670.94" y="1472.31" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4758.16 1507.51 L 4758.16 1544.64" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4698.16 1590.27 L 4660 1600.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4660 636.4 L 4834.16 713.75" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4694.43" y="655.89" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4698.16 1590.27 L 4655.99 1601.26" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4638.48 626.84 L 4834.16 713.75" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4672.91" y="646.33" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4894.16 770.4 L 4894.16 838.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4894.16 898.61 L 4894.16 928.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4834.16 1023.69 L 4787.96 1060.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4764.87" y="1044.42" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4864.09 1000.03 L 4787.96 1060.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4794.79" y="1020.76" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4894.16 1023.91 L 4894.16 1060.21" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4864.16" y="1046.26" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4919.67 1120.21 L 4955.68 1162.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4919.67 1120.21 L 4972.02 1181.77" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4996.21 1257.86 L 4996.21 1324.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4996.21" y="1276.42" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4996.21 1384.66 L 4996.21 1424.12" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4953.77 1257.86 L 4784.87 1447.51" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4925.72" y="1293.56" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4971.35 1238.12 L 4784.87 1447.51" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4943.31" y="1273.81" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4373.69 976.84 L 4373.69 1613.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4313.69 1677.78 L 4229.06 1701.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4284.19" y="1690.21" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4329.29 1673.43 L 4229.06 1701.4" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4299.79" y="1685.86" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4169.06 1748.14 L 4169.06 1795.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4169.06 1890.79 L 4169.06 1938.14" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4169.06" y="1909.36" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4169.06 1998.14 L 4169.06 2028.14" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4169.06 2100.04 L 4169.06 2154.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4169.06 2214.39 L 4169.06 2244.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4109.06 1843.14 L 4059.06 1843.14 L 4059.06 2230.64 L 4109.06 2250.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4109.06 1843.14 L 4059.06 1843.14 L 4059.06 2230.64 L 4117.43 2253.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4076.74" y="1817.34" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4373.69 1708.69 L 4373.69 1759.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4373.69" y="1727.21" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
@@ -263,53 +263,53 @@
 <text x="4373.69" y="2237.93" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4373.69 2328.59 L 4373.69 2377.78" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4316.64 2407.78 L 4286.64 2407.78" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4246.08 2377.78 L 4284.46 2318.59 L 4284.46 2128.99 L 4313.69 2143" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4433.69 1853.65 L 4496.46 1902.57" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4474.74" y="1889.85" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4686.78 2024.8 L 4616.46 2046" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4656.78" y="2047.55" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4603.72 2094.09 L 4666.06 2133.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4246.08 2377.78 L 4284.46 2318.59 L 4284.46 2128.99 L 4336.27 2153.81" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4403.97 1830.49 L 4526.17 1925.73" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4445.02" y="1866.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4703.29 2019.82 L 4616.46 2046" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4673.29" y="2042.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4603.72 2094.09 L 4692.71 2150.57" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4726.06 2219.39 L 4726.06 2263.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4726.06" y="2237.95" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4726.06 2323.79 L 4726.06 2361.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4726.06 2433.74 L 4726.06 2471.79" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4726.06 2531.79 L 4726.06 2569.84" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4786.06 2171.74 L 4826.86 2171.74 L 4826.86 2550.59 L 4786.06 2570.52" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4786.06 2171.74 L 4826.86 2171.74 L 4826.86 2550.59 L 4774.24 2576.3" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4813.79" y="2205.94" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4433.69 2193.63 L 4489.87 2214.13" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4462.73" y="2208.43" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4609.87 2255.7 L 4666.06 2274.12" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4640.72" y="2270.01" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4414.8 2186.74 L 4508.76 2221.03" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4443.84" y="2201.53" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4592.34 2249.95 L 4666.06 2274.12" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4623.18" y="2264.26" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4549.87 2283.68 L 4549.87 2322.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4519.87" y="2307.3" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 4550.53 2417.85 L 4550.94 2447.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4550.74" y="2437.7" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4550.52 2417.34 L 4550.94 2447.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4550.73" y="2437.19" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4551.35 2507.85 L 4551.35 2537.85" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4551.35 2609.75 L 4551.35 2653.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4489.87 2370.2 L 4464.46 2370.2 L 4464.46 2635.39 L 4496.91 2653.28" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4489.87 2370.2 L 4464.46 2370.2 L 4464.46 2635.39 L 4505.51 2658.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4464.47" y="2386.8" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 4806.78 2024.8 L 4877.11 2046" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4851.28" y="2042.41" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 4790.28 2019.82 L 4893.62 2050.98" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4834.77" y="2037.44" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4937.11 2111.74 L 4937.11 2178.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4937.11" y="2149.55" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 4937.11 2265.39 L 4937.11 2295.39" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4937.11 2367.29 L 4937.11 2406.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 4937.11 2466.19 L 4937.11 2505.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4995.99 2111.74 L 5095.39 2192.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5039.62" y="2151.25" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 4966.83 2088.14 L 5095.39 2192.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5010.46" y="2127.65" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5132.46 2252.19 L 5132.46 2288.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5132.46 2383.49 L 5132.46 2413.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5132.46" y="2402.06" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5072.46 2461.1 L 5050.06 2397.79 L 5039.66 2161.79 L 4973.26 2161.79 L 4973.26 2178.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5048.06" y="2438.32" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5072.47 2461.14 L 5050.06 2397.79 L 5039.66 2161.79 L 4973.26 2161.79 L 4973.26 2178.99" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5048.06" y="2438.33" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5132.46 2508.8 L 5132.46 2551.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5132.46" y="2527.33" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5132.46 2611.6 L 5132.46 2647.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5132.46 2719.23 L 5132.46 2749.23" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5161.54 2383.49 L 5264.14 2551.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5177.8" y="2414.33" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 5238.2 2611.6 L 5185.49 2647.33" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -254.9 L 5158.76 369.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 5152.04 2367.93 L 5264.14 2551.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5168.3" y="2398.77" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5238.2 2611.6 L 5173.89 2655.19" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1877.99 -255.32 L 5158.76 369.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5218.76 416.61 L 5218.76 482.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5218.76 542.61 L 5218.76 576.96" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5218.76 672.27 L 5218.76 726.92" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
@@ -319,56 +319,56 @@
 <path d="M 5218.76 961.07 L 5218.76 1004.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5218.76" y="979.61" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5218.76 1064.6 L 5218.76 1102.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5158.76 913.41 L 5110.35 913.41 L 5110.35 1171.81 L 5158.76 1202.38" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 5158.76 913.41 L 5110.35 913.41 L 5110.35 1171.81 L 5185.33 1219.16" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5127.22" y="917.61" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5218.76 1162.61 L 5218.76 1192.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5218.76 1287.92 L 5218.76 1339.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5188.76" y="1317.88" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 5278.76 1265.33 L 5871.15 1512.74" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5309.47" y="1332.38" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5278.76 659.71 L 5423.85 744.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5317.7" y="686.68" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5258.08 1256.69 L 5878.14 1515.66" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5288.8" y="1323.75" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5253.31 644.82 L 5423.85 744.58" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5292.25" y="671.8" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5475.15 804.58 L 5475.15 838.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5475.15 898.61 L 5475.15 928.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5257.08 822.23 L 5451.02 1063.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5280.87" y="856.01" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5242.14 803.66 L 5451.02 1063.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5265.93" y="837.44" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5475.15 1023.91 L 5475.15 1063.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5475.15" y="1042.44" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5475.15 1123.41 L 5475.15 1153.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5421.87 1248.72 L 5421.09 1249.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5387.81" y="1243.13" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5516.25 1248.72 L 5516.85 1249.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5527.15" y="1244.12" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
-<path d="M 5535.15 997.18 L 5751.15 1072.49" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5566.92" y="1012.46" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5446.92 1226.31 L 5420.69 1249.77" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5443.14" y="1252.67" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5499.54 1229.34 L 5516.85 1249.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5518.8" y="1234.43" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5516.84 990.8 L 5769.45 1078.88" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5548.61" y="1006.08" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5811.15 1141.07 L 5811.15 1198.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5781.15" y="1174.06" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5811.15 1258.61 L 5811.15 1288.61" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5811.15 1348.61 L 5811.15 1384.96" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5751.15 1093.41 L 5716.75 1093.41 L 5716.75 1376.61 L 5751.15 1397.02" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 5751.15 1093.41 L 5716.75 1093.41 L 5716.75 1376.61 L 5776.8 1412.24" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="5716.71" y="1118.01" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
-<path d="M 5766.53 1480.27 L 5738.44 1510.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5706.53" y="1504.65" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 5785.56 1459.94 L 5738.44 1510.27" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5725.56" y="1484.33" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 5710.35 1570.27 L 5710.35 1607.41" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 5868.11 1480.27 L 5893.67 1501.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="5889.87" y="1484.42" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 5840.37 1457.06 L 5893.67 1501.65" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="5855.8" y="1513.28" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 5941.55 1651.01 L 5941.55 1651.01" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5941.55 1686.96 L 5941.55 1728.53" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5941.55 1788.53 L 5941.55 1920.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 3088.75 661.75 L 3088.75 989.61 L 2877.38 1057.35" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 3088.75 661.75 L 3088.75 989.61 L 2860.13 1062.88" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="3088.75" y="680.33" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2817.38 1124.23 L 2817.38 1172.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="2817.38" y="1142.79" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 2817.38 1232.56 L 2817.38 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 2757.38 1122.69 L 2692.49 1172.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="2679.06" y="1149.25" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
+<path d="M 2786.89 1100.01 L 2692.49 1172.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="2708.56" y="1126.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <path d="M 2653.45 1232.56 L 2653.45 1262.56" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5475.15 416.61 L 5475.15 455.07" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <path d="M 5659.1 416.61 L 5659.1 455.07" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -255.7 L 5415.15 370.04" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 1880.16 -256.21 L 5599.1 370.55" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<path d="M 4616.46 1967.42 L 4686.78 1988.62" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
-<text x="4660.17" y="1989.62" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
+<path d="M 1878.21 -256.05 L 5415.15 370.04" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 1878.36 -256.52 L 5613.23 372.93" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<path d="M 4599.95 1962.45 L 4703.29 1993.6" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
+<text x="4643.67" y="1984.64" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">Yes</text>
 <path d="M 4556.46 1996.99 L 4556.46 2034.09" fill="none" stroke="#000000" stroke-width="1" marker-end="url(#arrow)"/>
 <text x="4571.12" y="2024.57" font-size="12" text-anchor="middle" stroke="#FFFFFF" stroke-width="3" paint-order="stroke">No</text>
 <g transform="translate(1760.16 -296.32) scale(1.02 1.03) translate(-1 -1)" style="stroke-width:0.97"><g fill="#FFFFFF" stroke="#000000" stroke-width="2" stroke-linejoin="miter" stroke-linecap="butt">

--- a/tools/render/render_graphml_svg.py
+++ b/tools/render/render_graphml_svg.py
@@ -301,13 +301,111 @@ def clip_to_rect(inside, outside, rect):
     return (x0 + dx * best_t, y0 + dy * best_t)
 
 
-def edge_polyline(edge, nodes):
+_ARC_STEPS = 8
+
+
+def _shape_ring(el, m):
+    """Ordered boundary points of the first drawn shape under `el`.
+
+    Unlike element_points, which yields every point of every element in no
+    particular order (it only ever feeds a bounding box), this returns a ring
+    that can be intersected with a segment.
+    """
+    tag = el.tag.split("}")[-1]
+    m = compose(m, parse_transform(el.get("transform")))
+    if tag == "polygon" and el.get("points"):
+        vals = [float(v) for v in re.split(r"[,\s]+", el.get("points").strip()) if v]
+        ring = [(vals[i], vals[i + 1]) for i in range(0, len(vals) - 1, 2)]
+    elif tag == "rect":
+        x, y = float(el.get("x", 0)), float(el.get("y", 0))
+        w, h = float(el.get("width", 0)), float(el.get("height", 0))
+        rx = min(float(el.get("rx", 0) or 0), w / 2)
+        ry = min(float(el.get("ry", el.get("rx", 0)) or 0), h / 2)
+        if rx <= 0 or ry <= 0:
+            ring = [(x, y), (x + w, y), (x + w, y + h), (x, y + h)]
+        else:
+            # corner centres, clockwise from top-left
+            ring = []
+            for cx, cy, a0 in ((x + rx, y + ry, math.pi),
+                               (x + w - rx, y + ry, -math.pi / 2),
+                               (x + w - rx, y + h - ry, 0.0),
+                               (x + rx, y + h - ry, math.pi / 2)):
+                for k in range(_ARC_STEPS + 1):
+                    a = a0 + (math.pi / 2) * k / _ARC_STEPS
+                    ring.append((cx + rx * math.cos(a), cy + ry * math.sin(a)))
+    elif tag in ("ellipse", "circle"):
+        cx, cy = float(el.get("cx", 0)), float(el.get("cy", 0))
+        rx = float(el.get("rx", el.get("r", 0)))
+        ry = float(el.get("ry", el.get("r", 0)))
+        steps = _ARC_STEPS * 4
+        ring = [(cx + rx * math.cos(2 * math.pi * k / steps),
+                 cy + ry * math.sin(2 * math.pi * k / steps)) for k in range(steps)]
+    elif tag == "path" and el.get("d"):
+        ring = list(path_points(el.get("d")))
+    else:
+        for child in el:
+            found = _shape_ring(child, m)
+            if found:
+                return found
+        return None
+    return [apply_matrix(m, px, py) for px, py in ring] if len(ring) >= 3 else None
+
+
+def node_ring(node, resources, cache={}):
+    """The node's outline in diagram coordinates, or None to fall back to its box."""
+    key = (node.refid, node.x, node.y, node.w, node.h)
+    if key in cache:
+        return cache[key]
+    res = resources.get(node.refid)
+    ring = None
+    if res:
+        group, (bx, by, bw, bh) = resource_group(res)
+        local = _shape_ring(group, IDENTITY)
+        if local:
+            sx = node.w / bw if bw else 1.0
+            sy = node.h / bh if bh else 1.0
+            ring = [(node.x + sx * (px - bx), node.y + sy * (py - by))
+                    for px, py in local]
+    cache[key] = ring
+    return ring
+
+
+def clip_to_ring(inside, outside, ring):
+    """Point where segment inside→outside first crosses the outline."""
+    x0, y0 = inside
+    dx, dy = outside[0] - x0, outside[1] - y0
+    best_t = 1.0
+    for i in range(len(ring)):
+        ax, ay = ring[i]
+        bx, by = ring[(i + 1) % len(ring)]
+        ex, ey = bx - ax, by - ay
+        den = dx * ey - dy * ex
+        if abs(den) < 1e-12:
+            continue
+        t = ((ax - x0) * ey - (ay - y0) * ex) / den
+        u = ((ax - x0) * dy - (ay - y0) * dx) / den
+        if 1e-9 < t < best_t and -1e-9 <= u <= 1 + 1e-9:
+            best_t = t
+    return (x0 + dx * best_t, y0 + dy * best_t)
+
+
+def clip_to_node(inside, outside, node, resources):
+    ring = node_ring(node, resources)
+    if ring is None:
+        return clip_to_rect(inside, outside, (node.x, node.y, node.w, node.h))
+    return clip_to_ring(inside, outside, ring)
+
+
+def edge_polyline(edge, nodes, resources):
     s, t = nodes[edge.src], nodes[edge.tgt]
     scx, scy = s.x + s.w / 2 + edge.sx, s.y + s.h / 2 + edge.sy
     tcx, tcy = t.x + t.w / 2 + edge.tx, t.y + t.h / 2 + edge.ty
     pts = [(scx, scy)] + edge.bends + [(tcx, tcy)]
-    pts[0] = clip_to_rect(pts[0], pts[1], (s.x, s.y, s.w, s.h))
-    pts[-1] = clip_to_rect(pts[-1], pts[-2], (t.x, t.y, t.w, t.h))
+    # Clip to the node's real outline, not its bounding box: on a diamond or
+    # hexagon the two differ by up to half the node's width, leaving the
+    # arrowhead floating in space short of the shape.
+    pts[0] = clip_to_node(pts[0], pts[1], s, resources)
+    pts[-1] = clip_to_node(pts[-1], pts[-2], t, resources)
     return pts
 
 
@@ -471,7 +569,7 @@ def render(nodes, edges, resources, crop=None, pad=0.0, restrict=None):
                 or rects_intersect((t.x, t.y, t.w, t.h), view_rect)
             ):
                 continue
-        pts = edge_polyline(e, nodes)
+        pts = edge_polyline(e, nodes, resources)
         d = "M " + " L ".join(f"{fnum(x)} {fnum(y)}" for x, y in pts)
         out.append(
             f'<path d="{d}" fill="none" stroke="#000000" stroke-width="1" '


### PR DESCRIPTION
Reported by @M0LTE: the arrows don't quite meet the diamonds, looking like they clip at the bounding box rather than joining the shape. That's exactly what was happening.

Rebased onto `main` now that #81 has landed, and the eight renders regenerated on top of that figure change.

## Cause

`edge_polyline` clipped both endpoints with `clip_to_rect` against the node's **axis-aligned bounding box**, whatever shape the node actually is:

```python
pts[0]  = clip_to_rect(pts[0],  pts[1],  (s.x, s.y, s.w, s.h))
pts[-1] = clip_to_rect(pts[-1], pts[-2], (t.x, t.y, t.w, t.h))
```

Exact for a rectangle, and exact for an orthogonal edge meeting a diamond at a vertex — where box and outline touch — which is why it went unnoticed for so long. Any other approach angle leaves the arrowhead short of the shape, in open space.

## Scale of it

Measured as the distance from each edge endpoint to the outline it should be touching — **172 of 1,673 endpoints landed off their shape, by up to 42.7px**:

| Figure | Before | After |
| --- | --- | --- |
| `DataLink_Subroutines.svg` | 45 / 131 | **0 / 88** |
| `DataLink_TimerRecovery.svg` | 66 / 535 | **3 / 446** |
| `DataLink_Connected.svg` | 31 / 405 | **2 / 365** |
| `DataLink_TimerRecovery.srej-received.svg` | 13 / 54 | **2 / 43** |
| `DataLink_AwaitingV22Connection.svg` | 7 / 161 | **2 / 148** |
| `DataLink_AwaitingConnection.svg` | 6 / 143 | **1 / 132** |
| `DataLink_AwaitingRelease.svg` | 2 / 124 | **0 / 114** |
| `DataLink_Disconnected.svg` | 2 / 120 | **1 / 112** |
| **total** | **172 / 1,673** | **11 / 1,448** |

Every original offender was on a `polygon` — diamonds and hexagons. Rectangles were already exact.

Of the 11 remaining, nine are under 1.5px: rounded-rect endpoints sitting just inside the sharp-cornered approximation the checker uses. The other two are the checker mis-attributing an endpoint to a node whose bounding box it happens to touch. I verified the worst-looking case by hand — the `Version 2.2?` decision in `DataLink_TimerRecovery` — and its edges now clip onto the diamond's faces.

(The endpoint totals fall too, 1,673 → 1,448, for the same reason the fix works: endpoints that used to sit on a bounding-box border, where the checker counts them, now sit on the shape.)

## Fix

The renderer already knew the true outline — each node draws a resource SVG scaled into its box, so the shape's geometry is right there. What was missing was an **ordered** ring: `element_points` yields every point of every element in arbitrary order, because it only ever fed a bounding box.

- `_shape_ring` returns an ordered ring for the first drawn shape, sampling arcs for rounded rectangles and ellipses.
- `node_ring` maps it into diagram coordinates through the same transform the node group is emitted with, and caches per node.
- `clip_to_ring` intersects the segment with the ring, taking the first crossing outward, matching `clip_to_rect`'s existing semantics.
- A node whose resource yields no usable shape falls back to `clip_to_rect`, so behaviour is never worse than before.

## Verification

- **Visually**, on the `Version 2.2?` decision: before, the `Yes`/`No` branches begin detached, floating at the bbox corners; after, they leave the diamond's lower faces. (Before/after crop shared with @M0LTE.)
- `render_all.py` is still **deterministic** — two consecutive runs produce an identical diff.
- **Structurally unchanged**: node and edge counts are identical on all eight figures, including #81's new diamond (`nodes 182→182, edges 211→211` on Connected). Geometry only.

The `svg figure diff` comment below is this change's own report, and its findings are all false positives by construction — nothing structural changed. Thirteen of them, down from 28 before #85; they are the residue documented there, chiefly edge endpoints being renamed as they move and the path-shaped-node label limitation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0188JcqNg5JDQqdsBt7LrbyE
