### PR TITLE
docs(findings): H1 reproduced on air; explorer reaches #43, #45, #48

### DIFF
--- a/docs/evidence/h1-timer-recovery-2026-09-10/h1-control.log
+++ b/docs/evidence/h1-timer-recovery-2026-09-10/h1-control.log
@@ -1,0 +1,20 @@
+# session opened 21:42:39
+21:42:39.562 TX      M0LTE>GB7RDG XID  P/F=1 cmd
+21:42:41.532 RX      GB7RDG>M0LTE XID  P/F=1 rsp
+21:42:41.604 TX      M0LTE>GB7RDG SABM P/F=1 cmd
+21:42:42.954 RX      GB7RDG>M0LTE UA   P/F=1 rsp
+21:42:43.252 RX      GB7RDG>M0LTE I   N(s)=0 N(r)=0 P=1 cmd info=79
+21:42:43.293 TX      M0LTE>GB7RDG RR   N(r)=1 F/P=1 rsp
+21:43:04.987 TX      M0LTE>GB7RDG I   N(s)=0 N(r)=1 P=0 cmd info=2
+21:43:06.346 RX      GB7RDG>M0LTE I   N(s)=1 N(r)=1 P=1 cmd info=63
+21:43:06.354 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 rsp
+21:43:57.663 RX      GB7RDG>GB7WOD RR   N(r)=3 F/P=1 rsp
+21:45:06.358 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 cmd
+21:45:07.876 RX      GB7RDG>M0LTE RR   N(r)=1 F/P=1 rsp
+21:46:43.603 RX      GB7RDG>GB7WOD RR   N(r)=3 F/P=1 rsp
+21:47:07.885 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 cmd
+21:47:08.000 RX      GB7RDG>M0LTE RR   N(r)=1 F/P=1 rsp
+21:47:54.973 TX      M0LTE>GB7RDG I   N(s)=1 N(r)=2 P=0 cmd info=2
+21:47:54.976 TX      M0LTE>GB7RDG DISC P/F=1 cmd
+21:47:56.884 RX      GB7RDG>M0LTE UA   P/F=1 rsp
+# session closed. counts: RX:I=2, RX:RR=4, RX:UA=2, RX:XID=1, TX:DISC=1, TX:I=2, TX:RR=4, TX:SABM=1, TX:XID=1

--- a/docs/evidence/h1-timer-recovery-2026-09-10/h1-control2.axcall.out
+++ b/docs/evidence/h1-timer-recovery-2026-09-10/h1-control2.axcall.out
@@ -1,0 +1,14 @@
+# run h1-control2 started 2026-09-10T20:54:52Z, tee args: 
+axcall: connecting to GB7RDG...
+axcall: connected to GB7RDG (mod-8, window 4, paclen 256, SREJ on)
+Welcome to GB7RDG. Sysop M0LTE. Ports on 40m, 6m, 2m, 70cm. 
+Type  ?  for Help
+READNG:GB7RDG} See https://ukpacketradio.network/nodes:gb7rdg 
+READNG:GB7RDG} Nodes
+GB7WOK-1            BASTOK:GB7BSK       BDHBBS:GB7BDH-3     BDHBBS:GB7BDH-1     
+BSKBBS:GB7BSK-1     BSKCHT:GB7BSK-4     CSCHAT:GB7NDH-3     CSNODE:GB7NDH-2     
+NDHBBS:GB7NDH-1     PARKER:GB7LAN       RDGBBS:GB7RDG-2     RDGCHT:GB7RDG-1     
+WODCHT:GB7WOD-1     WOODLY:GB7WOD       
+axcall: disconnected
+# axcall exit 0
+# run h1-control2 ended 2026-09-10T21:00:23Z

--- a/docs/evidence/h1-timer-recovery-2026-09-10/h1-control2.log
+++ b/docs/evidence/h1-timer-recovery-2026-09-10/h1-control2.log
@@ -1,0 +1,26 @@
+# session opened 21:54:52
+21:54:53.096 TX      M0LTE>GB7RDG XID  P/F=1 cmd
+21:54:54.444 RX      GB7RDG>M0LTE XID  P/F=1 rsp
+21:54:54.518 TX      M0LTE>GB7RDG SABM P/F=1 cmd
+21:54:55.554 RX      GB7RDG>M0LTE UA   P/F=1 rsp
+21:54:55.854 RX      GB7RDG>M0LTE I   N(s)=0 N(r)=0 P=1 cmd info=79
+21:54:55.878 TX      M0LTE>GB7RDG RR   N(r)=1 F/P=1 rsp
+21:55:00.756 RX      GB7RDG>GB7WOD RR   N(r)=3 F/P=1 rsp
+21:55:04.529 TX      M0LTE>GB7RDG I   N(s)=0 N(r)=1 P=0 cmd info=2
+21:55:06.235 RX      GB7RDG>M0LTE I   N(s)=1 N(r)=1 P=1 cmd info=63
+21:55:06.243 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 rsp
+21:55:18.514 TX      M0LTE>GB7RDG I   N(s)=1 N(r)=2 P=0 cmd info=2
+21:55:20.548 RX      GB7RDG>M0LTE I   N(s)=2 N(r)=2 P=0 cmd info=150
+21:55:20.938 RX      GB7RDG>M0LTE I   N(s)=3 N(r)=2 P=0 cmd info=150
+21:55:21.057 RX      GB7RDG>M0LTE I   N(s)=4 N(r)=2 P=1 cmd info=5
+21:55:21.058 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 rsp
+21:56:39.556 RX      GB7RDG>GB7WOD RR   N(r)=4 F/P=1 rsp
+21:57:21.067 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 cmd
+21:57:22.154 RX      GB7RDG>ID UI   P/F=0 cmd
+21:57:22.274 RX      GB7RDG>M0LTE RR   N(r)=2 F/P=1 rsp
+21:59:21.001 RX      GB7RDG>GB7WOD RR   N(r)=4 F/P=1 rsp
+21:59:22.277 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 cmd
+21:59:23.881 RX      GB7RDG>M0LTE RR   N(r)=2 F/P=1 rsp
+22:00:18.522 TX      M0LTE>GB7RDG DISC P/F=1 cmd
+22:00:19.786 RX      GB7RDG>M0LTE UA   P/F=1 rsp
+# session closed. counts: RX:I=5, RX:RR=5, RX:UA=2, RX:UI=1, RX:XID=1, TX:DISC=1, TX:I=2, TX:RR=5, TX:SABM=1, TX:XID=1

--- a/docs/evidence/h1-timer-recovery-2026-09-10/h1-drop.axcall.out
+++ b/docs/evidence/h1-timer-recovery-2026-09-10/h1-drop.axcall.out
@@ -1,0 +1,14 @@
+# run h1-drop started 2026-09-10T20:48:31Z, tee args: --drop-tx-i 2
+axcall: connecting to GB7RDG...
+axcall: connected to GB7RDG (mod-8, window 4, paclen 256, SREJ on)
+Welcome to GB7RDG. Sysop M0LTE. Ports on 40m, 6m, 2m, 70cm. 
+Type  ?  for Help
+READNG:GB7RDG} See https://ukpacketradio.network/nodes:gb7rdg 
+READNG:GB7RDG} Nodes
+GB7WOK-1            BASTOK:GB7BSK       BDHBBS:GB7BDH-3     BDHBBS:GB7BDH-1     
+BSKBBS:GB7BSK-1     BSKCHT:GB7BSK-4     CSCHAT:GB7NDH-3     CSNODE:GB7NDH-2     
+NDHBBS:GB7NDH-1     PARKER:GB7LAN       RDGBBS:GB7RDG-2     RDGCHT:GB7RDG-1     
+WODCHT:GB7WOD-1     WOODLY:GB7WOD       
+axcall: disconnected
+# axcall exit 0
+# run h1-drop ended 2026-09-10T20:54:03Z

--- a/docs/evidence/h1-timer-recovery-2026-09-10/h1-drop.log
+++ b/docs/evidence/h1-timer-recovery-2026-09-10/h1-drop.log
@@ -1,0 +1,25 @@
+# session opened 21:48:31
+21:48:32.270 TX      M0LTE>GB7RDG XID  P/F=1 cmd
+21:48:33.601 RX      GB7RDG>M0LTE XID  P/F=1 rsp
+21:48:33.667 TX      M0LTE>GB7RDG SABM P/F=1 cmd
+21:48:34.606 RX      GB7RDG>M0LTE UA   P/F=1 rsp
+21:48:34.892 RX      GB7RDG>M0LTE I   N(s)=0 N(r)=0 P=1 cmd info=79
+21:48:34.916 TX      M0LTE>GB7RDG RR   N(r)=1 F/P=1 rsp
+21:48:43.709 TX      M0LTE>GB7RDG I   N(s)=0 N(r)=1 P=0 cmd info=2
+21:48:45.104 RX      GB7RDG>M0LTE I   N(s)=1 N(r)=1 P=1 cmd info=63
+21:48:45.117 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 rsp
+21:48:57.694 TX DROP M0LTE>GB7RDG I   N(s)=1 N(r)=2 P=0 cmd info=2
+21:49:03.702 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 cmd
+21:49:05.206 RX      GB7RDG>M0LTE RR   N(r)=1 F/P=1 rsp
+21:49:05.212 TX      M0LTE>GB7RDG I   N(s)=1 N(r)=2 P=0 cmd info=2
+21:49:06.996 RX      GB7RDG>M0LTE I   N(s)=2 N(r)=2 P=0 cmd info=150
+21:49:07.386 RX      GB7RDG>M0LTE I   N(s)=3 N(r)=2 P=0 cmd info=150
+21:49:07.505 RX      GB7RDG>M0LTE I   N(s)=4 N(r)=2 P=1 cmd info=5
+21:49:07.506 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 rsp
+21:49:30.488 RX      GB7RDG>GB7WOD RR   N(r)=3 F/P=1 rsp
+21:52:11.918 RX      GB7RDG>GB7WOD RR   N(r)=3 F/P=1 rsp
+21:53:40.254 RX      GB7RDG>M0LTE RR   N(r)=2 F/P=1 cmd
+21:53:40.263 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 rsp
+21:53:57.701 TX      M0LTE>GB7RDG DISC P/F=1 cmd
+21:53:58.935 RX      GB7RDG>M0LTE UA   P/F=1 rsp
+# session closed. counts: RX:I=5, RX:RR=4, RX:UA=2, RX:XID=1, TX:DISC=1, TX:DROPPED=1, TX:I=3, TX:RR=5, TX:SABM=1, TX:XID=1

--- a/docs/evidence/h1-timer-recovery-2026-09-10/h1run.sh
+++ b/docs/evidence/h1-timer-recovery-2026-09-10/h1run.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# usage: h1run.sh <label> <wait-seconds> [tee args...]
+# One foreground run: tee on 8205 -> modem 8105 with the given fault args,
+# axcall M0LTE -> GB7RDG through the tee, two node commands from stdin, then
+# an idle wait long enough for the T3 keepalive to show (or not), then EOF.
+label=$1; wait=$2; shift 2
+log=~/axtest/$label.log; out=~/axtest/$label.axcall.out
+rm -f "$log" "$out"
+python3 /tmp/kisstee.py --listen 8205 --modem 127.0.0.1:8105 --log "$log" "$@" > ~/axtest/$label.tee.out 2>&1 &
+teepid=$!
+sleep 1
+date -u +"# run $label started %Y-%m-%dT%H:%M:%SZ, tee args: $*" | tee -a "$out"
+( sleep 12; printf "I\n"; sleep 14; printf "N\n"; sleep "$wait" ) \
+  | timeout 480 /tmp/axcall GB7RDG -s M0LTE -t 127.0.0.1:8205 --keepalive 120 --frack 6 >> "$out" 2>&1
+echo "# axcall exit $?" >> "$out"
+sleep 4
+kill $teepid 2>/dev/null; wait $teepid 2>/dev/null
+date -u +"# run $label ended %Y-%m-%dT%H:%M:%SZ" >> "$out"
+echo "=== $log"; cat "$log"; echo "=== $out"; cat "$out"

--- a/docs/fuzzing-the-figures-findings.md
+++ b/docs/fuzzing-the-figures-findings.md
@@ -11,9 +11,9 @@ This is the report the brief asked for ("suggest a report first"). Nothing here 
 - All three checkers now exist and run in CI in [packet-net/ax25sdl](https://github.com/packet-net/ax25sdl): a static totality and determinism lint ([#88](https://github.com/packet-net/ax25sdl/pull/88)), the reference interpreter with its prose-derived golden traces and the clean-room SREJ traces ([#75](https://github.com/packet-net/ax25sdl/pull/75), [#76](https://github.com/packet-net/ax25sdl/pull/76), both open since July, now merged), and a two-station bounded explorer with a calibration suite ([#89](https://github.com/packet-net/ax25sdl/pull/89)).
 - **The figures are total and deterministic.** Every (state, event) arm and every subroutine selects exactly one path over every feasible valuation of its guard atoms. This was also true before the #40 fix, so a static check could not have found #40, as the brief expected.
 - **The calibration score is 10 of 11.** Between the explorer's invariants and the golden traces, every known defect except #41 (a numeric timer property) is rediscovered. The explorer alone finds #40 on the pre-fix tables and goes silent on the fixed ones, and finds #42, #47, #9 and the #44/#48 connect-phase pair unprompted on the current tables, with counterexamples of 2 to 30 steps.
-- **One novel hypothesis, H1:** a station can enter Timer Recovery and never leave it, because figc4.5 exits only on an F=1 supervisory response and has no T3 arm, so an acknowledgement that arrives on an I frame strands it with T1 stopped. direwolf's source carries an author's note describing the same symptom and a coded workaround. It was the dominant signature on the exploration grid (66 of 116 violating cells), and **it reproduces on packet.net's runtime in both quirk modes** ([packet.net#811](https://github.com/packet-net/packet.net/pull/811)): the stranded station never sends a keepalive poll, and with the figure run as drawn the retry counter ratchets across recoveries on a working link until N2 declares it dead.
+- **One novel hypothesis, H1:** a station can enter Timer Recovery and never leave it, because figc4.5 exits only on an F=1 supervisory response and has no T3 arm, so an acknowledgement that arrives on an I frame strands it with T1 stopped. direwolf's source carries an author's note describing the same symptom and a coded workaround. It was the dominant signature on the exploration grid (66 of 116 violating cells), **it reproduces on packet.net's runtime in both quirk modes** ([packet.net#811](https://github.com/packet-net/packet.net/pull/811)), and **it reproduces on air**: M0LTE to GB7RDG on 40m, one dropped frame, and the stranded station sent no keepalive poll in 290 s where the control sent two ([transcripts](evidence/h1-timer-recovery-2026-09-10/)). With the figure run as drawn the retry counter also ratchets across recoveries on a working link until N2 declares it dead.
 - **Nothing else surfaced.** A 576-cell grid over the current tables produced no violation that is not H1, #42 or #47 at k of 4 or less.
-- Still to do: the differential step (reproduce H1 against LinBPQ through the oracle stack), then file it; close #38, which PR #65 fixed without closing; and extend the explorer's move set so it can reach #43 and #45.
+- Done since the first draft: #38 closed; the explorer gained flow-control moves and a v2.0 stub peer ([ax25sdl#90](https://github.com/packet-net/ax25sdl/pull/90)) and now reaches seven of the nine live defects on its own; H1 reproduced on air. Still to do: file H1 as an erratum (evidence is complete), fix the two packet.net defects it exposed, and the citation pass on Timer Recovery.
 
 ---
 
@@ -89,12 +89,14 @@ Pre-fix tables were regenerated from this repository's history with the current 
 | #9 acknowledgement progress does not reset RC | current | 3 frames, N2=2, 3 drops restricted to interior I frames | deadlock: both stations Disconnected after DL-ERROR (T) with every frame delivered and acknowledged | 30 |
 | #13 window at half the modulus | current | k=7, drop+dup, SREJ off | reject coherence, receiver side, on a wrapped duplicate at distance 6. **Classified as the protocol's own constraint, not a figure defect**; clean at k=4 | 13 |
 | #44 mod-128 connect routes to the wrong state, #48 DM to a SABME tears down | current | Disconnected seed, A at modulo 128, peer declines SABME | deadlock: A sits in AwaitingConnection after SABME, the DM disconnects it, the data is lost | 2 |
-| #43 DL-FLOW-OFF on the wrong branch | current | not reached: no `DL_FLOW_OFF_request` move | golden trace | |
-| #45 FRMR fallback does not re-establish at v2.0 | current | not reached: nothing generates FRMR | golden trace | |
+| #43 DL-FLOW-OFF on the wrong branch | current | A sends 2, B's layer 3 turns flow off after its first delivery (flow-control moves, [ax25sdl#90](https://github.com/packet-net/ax25sdl/pull/90)) | busy-tracks-flow: B takes the empty not-busy arm and stays silent; with that check off, a frame is delivered upward with flow off, at 5 | 3 |
+| #45 FRMR fallback does not re-establish at v2.0 | current | A already in Awaiting v2.2 Connection, a stub v2.0 peer that answers SABME with FRMR (every rule cited to the 1984 spec) | timer-free progress: the fallback emits SABME again and the link comes up only through a T1 retry's SABM | 4 |
+| #44 masks #45 from a cold connect | current | the brief's cold seed against the same FRMR stub | timer-free progress: A lands on figc4.2 (#44), whose catch-all swallows the FRMR, so figc4.6's fallback is never attempted. The brief expected the connect to loop; it does not, because figc4.2 retries with SABM | 2 |
+| #48 DM to a SABME tears down (figc4.6 itself) | current | same seed, stub answers DM | deadlock: figc4.6 goes to Disconnected with no fallback; a new golden trace (strict xfail on #48) says what should have happened | 2 |
 | #54 Set_Version_2_2 never invoked | current | reached but invisible in 3 frames | golden trace | |
 | #41 Karn SRT sampling | | out of scope: symbolic timers | not caught | |
 
-Reading it plainly: the invariants have teeth. They discriminate on #40, rediscover four live defects without being told where to look, reach the connect-phase pair in two steps, and correctly classify the k=7 trap. Their blind spots are honest and documented: an inefficiency that still delivers in order (#38), anything numeric (#41), and moves the model does not yet make (#43, #45). The first #9 attempt is worth remembering as a method lesson: with unrestricted drops the explorer found only "three polls lost, N2 exhausted", which is N2 doing its job; the scenario had to restrict losses to interior I frames to isolate the defect.
+Reading it plainly: the invariants have teeth. They discriminate on #40, rediscover seven of the nine live defects without being told where to look (four in the first build, three more once the model gained flow-control moves and a v2.0 stub peer), and correctly classify the k=7 trap. Their blind spots are honest and documented: an inefficiency that still delivers in order (#38), anything numeric (#41), and a modulus split this abstract frame model cannot see (#54). One assumption in the brief did not survive contact: from a cold connect #44 masks #45, because figc4.2 swallows the FRMR and retries with SABM, so the fallback loop the brief expected never starts. The first #9 attempt is worth remembering as a method lesson: with unrestricted drops the explorer found only "three polls lost, N2 exhausted", which is N2 doing its job; the scenario had to restrict losses to interior I frames to isolate the defect.
 
 ---
 
@@ -114,7 +116,42 @@ Corroboration: direwolf's `i_frame()` in `src/ax25_link.c` (at eda1383f) carries
 
 Candidate fix, for the working group rather than this report: either an exit to Connected from the figc4.5 `I_received` arm when the acknowledgement clears the window (direwolf's shape), or a T3 arm in figc4.5, and the RC reset of #9 alongside.
 
-**Reproduced on packet.net.** A deterministic two-station harness test ([packet.net#811](https://github.com/packet-net/packet.net/pull/811)) replays the model's trace on the real runtime with the ack riding on the peer's I frame. In both the default and the strictly-faithful quirk modes the station ends in Timer Recovery with V(s)=V(a), T1 stopped, T3 running and RC=1. A T3 expiry then does nothing: the event has no arm in figc4.5 and the runtime drops it, so no keepalive poll is ever sent. The peer's own polls are answered with RR F=1 and change nothing. The next data restarts T1 with RC still 1, so its first expiry counts as the second retry. Across repeated recoveries the default mode's #9 quirk clamps RC at 2; the faithful figure ratchets 1, 2, 3 and on the next loss tears down a link that was delivering everything (DL-ERROR I, DM, both ends Disconnected), which is direwolf's "rc crept up slowly" note exactly. The control case, the same recovery with the ack on an RR, completes through the poll cycle and returns to Connected with RC=0; only the ack carrier differs. So this is now a figure defect visible in a faithful runtime, not only in a model, and the remaining step before filing is the on-air reproduction against LinBPQ.
+**Reproduced on packet.net.** A deterministic two-station harness test ([packet.net#811](https://github.com/packet-net/packet.net/pull/811)) replays the model's trace on the real runtime with the ack riding on the peer's I frame. In both the default and the strictly-faithful quirk modes the station ends in Timer Recovery with V(s)=V(a), T1 stopped, T3 running and RC=1. A T3 expiry then does nothing: the event has no arm in figc4.5 and the runtime drops it, so no keepalive poll is ever sent. The peer's own polls are answered with RR F=1 and change nothing. The next data restarts T1 with RC still 1, so its first expiry counts as the second retry. Across repeated recoveries the default mode's #9 quirk clamps RC at 2; the faithful figure ratchets 1, 2, 3 and on the next loss tears down a link that was delivering everything (DL-ERROR I, DM, both ends Disconnected), which is direwolf's "rc crept up slowly" note exactly. The control case, the same recovery with the ack on an RR, completes through the poll cycle and returns to Connected with RC=0; only the ack carrier differs. So this is now a figure defect visible in a faithful runtime, not only in a model.
+
+**Reproduced on air.** 10 September 2026, 21:48 local, M0LTE (axcall 0.2.27, the packet.net stack) to GB7RDG (LinBPQ 6.0.25.23) on 40 m, QPSK 3600, a very clean link. The KISS tee on radio1 sat between axcall and the modem and dropped exactly one frame, our second I frame, on its way to the modem; nothing else was touched. axcall ran with the keepalive at 120 s so its own T3 poll would land well before GB7RDG's 275 s poll. Two node commands were typed; GB7RDG answers a command on I frames with the acknowledgement piggybacked and P=1 on the last frame of the burst, which is what puts the clearing acknowledgement on an I frame. Verbatim transcripts, the run script and axcall's output are in [`evidence/h1-timer-recovery-2026-09-10/`](evidence/h1-timer-recovery-2026-09-10/).
+
+The drop run, decoded by the tee (`h1-drop.log`):
+
+```
+21:48:43.709 TX      M0LTE>GB7RDG I   N(s)=0 N(r)=1 P=0 cmd info=2      "I" command
+21:48:45.104 RX      GB7RDG>M0LTE I   N(s)=1 N(r)=1 P=1 cmd info=63     reply, acks our I(0)
+21:48:45.117 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 rsp
+21:48:57.694 TX DROP M0LTE>GB7RDG I   N(s)=1 N(r)=2 P=0 cmd info=2      "N" command, dropped by the tee
+21:49:03.702 TX      M0LTE>GB7RDG RR   N(r)=2 F/P=1 cmd                 T1 (6 s): poll, enter Timer Recovery
+21:49:05.206 RX      GB7RDG>M0LTE RR   N(r)=1 F/P=1 rsp                 partial: N(r)=1, V(s)=2
+21:49:05.212 TX      M0LTE>GB7RDG I   N(s)=1 N(r)=2 P=0 cmd info=2      retransmission, stay in Timer Recovery
+21:49:06.996 RX      GB7RDG>M0LTE I   N(s)=2 N(r)=2 P=0 cmd info=150    the clearing ack, on an I frame
+21:49:07.386 RX      GB7RDG>M0LTE I   N(s)=3 N(r)=2 P=0 cmd info=150
+21:49:07.505 RX      GB7RDG>M0LTE I   N(s)=4 N(r)=2 P=1 cmd info=5
+21:49:07.506 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 rsp                 answer to the P=1; T1 stopped, T3 started
+21:53:40.254 RX      GB7RDG>M0LTE RR   N(r)=2 F/P=1 cmd                 GB7RDG's own keepalive, 273 s later
+21:53:40.263 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 rsp                 answered; still no exit
+21:53:57.701 TX      M0LTE>GB7RDG DISC P/F=1 cmd                        end of run
+```
+
+Between 21:49:07 and 21:53:57, 290 s of idle, M0LTE sent nothing of its own. Its keepalive was due at 21:51:07 and never came.
+
+The control run, identical except that nothing was dropped (`h1-control2.log`), ends the same exchange at 21:55:21 and then polls twice:
+
+```
+21:55:21.058 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 rsp                 last exchange
+21:57:21.067 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 cmd                 keepalive at +120 s
+21:57:22.274 RX      GB7RDG>M0LTE RR   N(r)=2 F/P=1 rsp
+21:59:22.277 TX      M0LTE>GB7RDG RR   N(r)=5 F/P=1 cmd                 keepalive at +240 s
+21:59:23.881 RX      GB7RDG>M0LTE RR   N(r)=2 F/P=1 rsp
+```
+
+Same link, same commands, same replies, same P=1 on the last reply frame; the one dropped frame is the only difference, and it turns the keepalive off for the rest of the session. This is the evidence class the brief asked for: a dated transcript of a deployed stack following the figure and misbehaving on air. What is still not shown is LinBPQ itself being stranded; LinBPQ does not structure its link layer around a Timer Recovery state, so it is not expected to be, and its 273 s poll arriving on schedule in the drop run is consistent with that. The erratum stands on the figure, the prose, the model, the faithful runtime and the transcript; direwolf's note is the second implementation that met it.
 
 **A runtime-only defect seen in the same trace** (packet.net, not the figure): figc4.5's partial-ack arm ends with "Set Acknowledge Pending" and raises no LM-SEIZE, relying on the retransmitted frames popping off the queue to clear the flag. packet.net replays retransmissions inline (so they keep their original N(s)) and never runs the pop arm, so the flag stays set; the peer's next I frame then hits the "ack already pending" arm and is not acknowledged until the peer's own T1 poll. That costs the peer a T1 after every partial-ack recovery, stuck or not. It is pinned by the same test and filed as [packet.net#812](https://github.com/packet-net/packet.net/issues/812).
 
@@ -173,6 +210,7 @@ Timer Recovery is where H1 lives, where #38 and #47 lived, and where 41 percent 
 - An invariant cannot see an inefficiency that still delivers in order, so #38-class defects are the traces' territory.
 - Timers are symbolic. Anything numeric (#41, Karn, T1 backoff) is out of reach until a numeric extension exists.
 - T3 is disabled in the explorer and T1 fires only when nothing is in flight. Premature-timeout interleavings are not explored.
+- The DL-FLOW-OFF and DL-FLOW-ON busy arms in figc4.4 and figc4.5 emit RNR and RR with no N(r) staging box, unlike every other supervisory emission in the figures. Unreachable today because of #43; the moment #43 is fixed, a literal reading has no N(r) to send. Recorded in ax25sdl `docs/explorer.md` as H3 so the fix adds the box rather than trading one failure for another.
 - The channel does not reorder, on the grounds that a single AX.25 channel does not; the N(r) validity checks presuppose order.
 - k above half the modulus is unsound by construction and every calibration case except #13 runs at k of 4 or less.
 - Selective-recovery progress is implemented but unproven.
@@ -182,8 +220,8 @@ Timer Recovery is where H1 lives, where #38 and #47 lived, and where 41 percent 
 
 ## Recommended next steps
 
-1. **Differential, step 4 of the brief.** Reproduce H1 against LinBPQ through the pdn-bbs oracle stack and the KISS tee: bidirectional data, lose one I frame from the LinBPQ side's peer, let the acknowledgement ride on an I frame, then watch whether LinBPQ's keepalive poll ever comes. A dated transcript is what turns H1 into an erratum.
-2. **File H1** once reproduced on air, with the packet.net reproduction and the direwolf note as the second and third pieces of evidence, and propose the fix shape above together with #9. Decide in packet.net whether to carry a quirk (an exit to Connected on a clearing I-frame ack, direwolf's shape) ahead of the figure fix, since the runtime is exposed today.
+1. **File H1** as a figure-defect issue: the on-air transcript, the packet.net reproduction and the direwolf note are the evidence, and the fix shape above goes with #9. Decide in packet.net whether to carry a quirk (an exit to Connected on a clearing I-frame ack, direwolf's shape) ahead of the figure fix, since the runtime is exposed today: any pdn node that recovers from a loss with the peer's data flowing loses its keepalive until it next sends.
+2. **Differential against LinBPQ proper** (step 4 of the brief) remains open for the other hypotheses; the mirror of the H1 run, with LinBPQ as the recovering side, would say whether its retry counting has the #9 shape.
 3. **Fix the packet.net acknowledge-pending defect** left behind by inline retransmission ([packet.net#812](https://github.com/packet-net/packet.net/issues/812)), which is independent of the figure.
 4. **Close #38.**
 5. **Extend the explorer's move set** with `DL_FLOW_OFF_request` / `DL_FLOW_ON_request` and a v2.0 peer model that answers SABME with FRMR or DM, so #43, #45 and #48 become reachable as invariant violations rather than trace expectations.


### PR DESCRIPTION
Two updates to the findings report.

**H1 reproduced on air.** M0LTE (axcall 0.2.27, the packet.net stack) to GB7RDG (LinBPQ 6.0.25.23) on 40 m QPSK 3600, 10 September 2026. The KISS tee dropped exactly one of our I frames; T1 polled, GB7RDG answered F=1 with a partial N(r), we retransmitted, and the clearing acknowledgement came back on GB7RDG's reply I frames. From that point the station sent no keepalive poll in 290 s. The identical control run, nothing dropped, polled at +120 s and +240 s. Transcripts, axcall output and the run script are checked in verbatim under `docs/evidence/h1-timer-recovery-2026-09-10/`. The report's H1 section now carries the decoded exchange and says what the transcript does and does not show (LinBPQ itself is not stranded, and is not expected to be).

**Explorer reach.** With packet-net/ax25sdl#90 the two-station explorer has flow-control moves and a hand-written v2.0 peer, and reaches #43, #45 and #48 without being told where to look, seven of the nine live defects. One assumption in the brief is corrected: from a cold connect #44 masks #45, since figc4.2 swallows the FRMR and retries with SABM. The calibration table, the reading paragraph, the limits (a new H3 note on the busy arms' missing N(r) staging) and the next steps are updated; filing H1 is now the first item.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014qyx5dT8rmRTb8szT4SpEQ
